### PR TITLE
feat: Add keybinding management and window layout examples

### DIFF
--- a/README.org
+++ b/README.org
@@ -223,7 +223,7 @@ The generated project file includes template functions and usage instructions.
 *** Session Control
 - =enkan-repl-start-eat= - Start eat terminal emulator session. Determines directory from current buffer filename if it's a persistent file. Checks for existing sessions to prevent double startup.
 - =enkan-repl-finish-eat= - Terminate eat session and close its buffer. Determines directory from current buffer filename if it's a persistent file.
-- =enkan-repl-setup-window-layout= - Arrange windows for (the author's) optimal workflow
+- =enkan-repl-setup= - Arrange windows for (the author's) optimal workflow
 - =enkan-repl-list-sessions= - Display a list of active enkan sessions with interactive selection. Users can select a session, then choose action: (s)witch, (d)elete, or (q)uit.
 
 *** Utilities

--- a/enkan-repl-constants.el
+++ b/enkan-repl-constants.el
@@ -24,7 +24,7 @@
     ("enkan-repl-open-project-input-file" . "Open or create project input file for DIRECTORY. If DIRECTORY is nil, use current `default-directory'. If project input file exists, open it directly. If not exists, create from template then open.  Category: Utilities")
     ("enkan-repl-start-eat" . "Start eat terminal emulator session. Determines directory from current buffer filename if it's a persistent file. Checks for existing sessions to prevent double startup.  Category: Session Controller")
     ("enkan-repl-finish-eat" . "Terminate eat session and close its buffer. Determines directory from current buffer filename if it's a persistent file.  Category: Session Controller")
-    ("enkan-repl-setup-window-layout" . "Set up window layout with org file on left and eat on right. This is the author's preference - customize as needed.  Category: Session Controller")
+    ("enkan-repl-setup" . "Set up window layout with org file on left and eat on right. This is the author's preference - customize as needed.  Category: Session Controller")
     ("enkan-repl-output-template" . "Output current template content to a new buffer for customization.  Category: Utilities")
     ("enkan-repl-status" . "Show detailed diagnostic information for troubleshooting connection issues.  Category: Utilities")
     ("enkan-repl-list-sessions" . "Display a list of active enkan sessions with interactive selection. Users can select a session, then choose action: (s)witch, (d)elete, or (q)uit.  Category: Session Controller")

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -265,7 +265,7 @@ Returns the template path to use, or nil to use default template."
                (insert "- ~M-x enkan-repl-send-escape~ - Send ESC key to interrupt operations\n")
                (insert "- ~M-x enkan-repl-open-project-input-file~ - Open or create project input file\n")
                (insert "- ~M-x enkan-repl-start-eat~ - Start eat terminal session\n")
-               (insert "- ~M-x enkan-repl-setup-window-layout~ - Set up convenient window layout\n")
+               (insert "- ~M-x enkan-repl-setup~ - Set up convenient window layout\n")
                (insert "- ~M-x enkan-repl-output-template~ - Export template for customization\n")
                (insert "- ~M-x enkan-repl-status~ - Show diagnostic information\n")
                (insert "- ~M-x enkan-repl-toggle-debug-mode~ - Toggle debug mode\n")
@@ -359,7 +359,7 @@ Returns categorized functions as string, or falls back to static list."
           "- ~M-x enkan-repl-send-escape~ - Send ESC key to eat session buffer.\n\n"
           "** Session Controller\n\n"
           "- ~M-x enkan-repl-start-eat~ - Start eat terminal and change to appropriate directory.\n"
-          "- ~M-x enkan-repl-setup-window-layout~ - Set up window layout with org file on left and eat on right.\n\n"
+          "- ~M-x enkan-repl-setup~ - Set up window layout with org file on left and eat on right.\n\n"
           "** Utilities\n\n"
           "- ~M-x enkan-repl-open-project-input-file~ - Open or create project input file for current directory.\n"
           "- ~M-x enkan-repl-output-template~ - Output current template content to a new buffer for customization.\n"
@@ -914,7 +914,7 @@ Category: Session Controller"
 
 
 ;;;###autoload
-(defun enkan-repl-setup-window-layout ()
+(defun enkan-repl-setup ()
   "Set up window layout with org file on left and eat on right.
 This is the author's preference - customize as needed.
 

--- a/examples/dual-task-window-layout.el
+++ b/examples/dual-task-window-layout.el
@@ -1,0 +1,609 @@
+;;; dual-task-window-layout.el --- Dual task window layout for enkan-repl -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; Keywords: convenience, tools
+
+;; This file is NOT part of GNU Emacs.
+
+;; This file is an example configuration for enkan-repl.
+;; It provides a dual-task window layout for managing two enkan-repl sessions simultaneously.
+
+;;; Commentary:
+
+;; This example provides a dual-task window layout configuration:
+;; - Left: Two input file buffers vertically split (main 65%, sub 35%)
+;; - Middle: Main enkan-eat buffer (40% width)
+;; - Right: Sub enkan-eat buffer (30% width)
+;;
+;; Window width ratio: 3:4:3 (input:main-eat:sub-eat)
+;;
+;; Features:
+;; - Quick switching between input files only (C-t)
+;; - Automatically selects two enkan-eat sessions
+;; - Main task for active work, sub task for background processing
+;; - Cheat-sheet integration with enkan-repl
+;;
+;; Usage:
+;; 1. Start at least 2 enkan-repl sessions:
+;;    M-x enkan-repl-start-eat (repeat for each session)
+;;
+;; 2. Load this file:
+;;    (load-file "/path/to/enkan-repl/examples/dual-task-window-layout.el")
+;;
+;; 3. Initialize layout:
+;;    M-x enkan-dual-task-setup
+;;
+;; 4. Use keybindings:
+;;    C-t - Switch between input windows
+
+;;; Code:
+
+(require 'enkan-repl)
+
+;; Load keybinding definitions and base keymap
+(let ((constants-file (expand-file-name "keybinding-constants.el"
+                        (file-name-directory load-file-name)))
+       (keybinding-file (expand-file-name "keybinding.el"
+                          (file-name-directory load-file-name))))
+  (when (file-exists-p constants-file)
+    (load constants-file))
+  (when (file-exists-p keybinding-file)
+    (load keybinding-file)
+    ;; Install base keybindings as default
+    (when (fboundp 'enkan-install-base-keymap)
+      (enkan-install-base-keymap))))
+
+;;; ========================================
+;;; Customization Variables
+;;; ========================================
+
+(defcustom enkan-dual-task-input-column-ratio 0.4
+  "Width ratio for input column (0.0 to 1.0)."
+  :type 'float
+  :group 'enkan-repl)
+
+(defcustom enkan-dual-task-main-eat-ratio 0.4
+  "Width ratio for main eat window (0.0 to 1.0)."
+  :type 'float
+  :group 'enkan-repl)
+
+(defcustom enkan-dual-task-main-input-ratio 0.55
+  "Height ratio for main input window (0.0 to 1.0)."
+  :type 'float
+  :group 'enkan-repl)
+
+;;; ========================================
+;;; Internal Variables
+;;; ========================================
+
+(defvar enkan-dual-task-main-input-buffer nil
+  "Buffer for main task input file.")
+
+(defvar enkan-dual-task-sub-input-buffer nil
+  "Buffer for sub task input file.")
+
+(defvar enkan-dual-task-main-eat-buffer nil
+  "Buffer for main task eat session.")
+
+(defvar enkan-dual-task-sub-eat-buffer nil
+  "Buffer for sub task eat session.")
+
+(defvar enkan-dual-task-main-input-window nil
+  "Window for main task input file.")
+
+(defvar enkan-dual-task-sub-input-window nil
+  "Window for sub task input file.")
+
+(defvar enkan-dual-task-main-eat-window nil
+  "Window for main task eat session.")
+
+(defvar enkan-dual-task-sub-eat-window nil
+  "Window for sub task eat session.")
+
+(defvar enkan-dual-task-mode-map nil
+  "Keymap for dual task layout commands.")
+
+(defvar enkan-dual-task-cheat-sheet-candidates
+  (if (boundp 'enkan-dual-task-command-definitions)
+      ;; Use centralized definitions with keybinding hints
+      (mapcar (lambda (def)
+                (let* ((command (nth 0 def))
+                       (description (nth 1 def))
+                       (command-name (symbol-name command))
+                       ;; Find keybinding if exists
+                       (key (when (boundp 'enkan-dual-task-keybinding-overrides)
+                              (car (seq-find (lambda (binding)
+                                               (eq (nth 1 binding) command))
+                                             enkan-dual-task-keybinding-overrides)))))
+                  (cons command-name
+                        (if key
+                            (format "%s (%s)" description key)
+                          description))))
+              enkan-dual-task-command-definitions)
+    ;; Fallback definitions
+    '(("enkan-dual-task-setup" . "Setup dual task window layout")
+      ("enkan-dual-task-reset" . "Reset dual task layout")
+      ("enkan-dual-task-describe-layout" . "Show dual task layout status")
+      ("enkan-dual-task-switch-input" . "Switch between input windows (C-t)")))
+  "Additional commands for dual task layout to add to cheat sheet.")
+
+;;; ========================================
+;;; Keymap Definition
+;;; ========================================
+
+(setq enkan-dual-task-mode-map
+  (if (boundp 'enkan-dual-task-keybinding-overrides)
+      ;; Use centralized definitions if available
+      (enkan-keybinding-make-keymap enkan-dual-task-keybinding-overrides)
+    ;; Fallback to manual definition
+    (let ((map (make-sparse-keymap)))
+      (define-key map (kbd "C-t") 'enkan-dual-task-switch-input)
+      map)))
+
+;;; ========================================
+;;; Minor Mode Definition
+;;; ========================================
+
+(define-minor-mode enkan-dual-task-mode
+  "Minor mode for dual task window layout with enkan-repl."
+  :lighter " DualTask"
+  :keymap enkan-dual-task-mode-map
+  :global t
+  (if enkan-dual-task-mode
+      (progn
+        (enkan-dual-task-setup-cheat-sheet-advice)
+        (message "enkan-dual-task-mode enabled. C-t to switch between input files."))
+    (progn
+      (enkan-dual-task-remove-cheat-sheet-advice)
+      (message "enkan-dual-task-mode disabled."))))
+
+;;; ========================================
+;;; Main Setup Functions
+;;; ========================================
+
+(defun enkan-dual-task-setup ()
+  "Setup dual task window layout."
+  (interactive)
+
+  ;; Select two enkan-eat sessions
+  (let ((sessions (enkan-dual-task-select-sessions)))
+    (unless sessions
+      (error "Need at least 2 enkan-repl sessions. Please start them first"))
+
+    (setq enkan-dual-task-main-eat-buffer (car sessions))
+    (setq enkan-dual-task-sub-eat-buffer (cadr sessions))
+
+    ;; Get corresponding input files
+    (setq enkan-dual-task-main-input-buffer
+          (enkan-dual-task-get-input-buffer-for-eat enkan-dual-task-main-eat-buffer))
+    (setq enkan-dual-task-sub-input-buffer
+          (enkan-dual-task-get-input-buffer-for-eat enkan-dual-task-sub-eat-buffer))
+
+    ;; Setup window layout
+    (enkan-dual-task-window-setup)
+
+    ;; Setup display-buffer rules (currently minimal, can be extended)
+    (enkan-dual-task-setup-display-buffer-rules)
+
+    ;; Enable mode
+    (enkan-dual-task-mode 1)
+
+    (message "Dual task layout initialized. Main: %s, Sub: %s"
+             (buffer-name enkan-dual-task-main-eat-buffer)
+             (buffer-name enkan-dual-task-sub-eat-buffer))))
+
+(defun enkan-dual-task-reset ()
+  "Reset all dual task related variables and remove advices."
+  (interactive)
+  ;; Clear variables
+  (setq enkan-dual-task-main-input-buffer nil
+        enkan-dual-task-sub-input-buffer nil
+        enkan-dual-task-main-eat-buffer nil
+        enkan-dual-task-sub-eat-buffer nil
+        enkan-dual-task-main-input-window nil
+        enkan-dual-task-sub-input-window nil
+        enkan-dual-task-main-eat-window nil
+        enkan-dual-task-sub-eat-window nil)
+
+  ;; Remove any advices if added
+  (advice-remove 'display-buffer #'enkan-dual-task-display-buffer-advice)
+
+  ;; Disable the mode
+  (enkan-dual-task-mode -1)
+
+  (message "Dual task layout reset."))
+
+;;; ========================================
+;;; Window Layout Functions
+;;; ========================================
+
+(defun enkan-dual-task-window-setup ()
+  "Set up fundamental dual task window layout."
+  ;; Start fresh
+  (delete-other-windows)
+
+  ;; Switch to main input buffer
+  (switch-to-buffer enkan-dual-task-main-input-buffer)
+  (setq enkan-dual-task-main-input-window (selected-window))
+
+  ;; Create three vertical columns (3:4:3 ratio)
+  ;; Total width = 10 units, left=3, middle=4, right=3
+  (let* ((total-width (window-width))
+         (left-width (floor (* total-width enkan-dual-task-input-column-ratio)))
+         (middle-width (floor (* total-width enkan-dual-task-main-eat-ratio))))
+
+    ;; Split for middle column
+    (split-window-horizontally left-width)
+    (other-window 1)
+    (setq enkan-dual-task-main-eat-window (selected-window))
+
+    ;; Split for right column
+    (split-window-horizontally middle-width)
+    (other-window 1)
+    (setq enkan-dual-task-sub-eat-window (selected-window))
+
+    ;; Go back to left column and split vertically (65:35)
+    (select-window enkan-dual-task-main-input-window)
+    (let ((main-height (floor (* (window-height) enkan-dual-task-main-input-ratio))))
+      (split-window-vertically main-height))
+    (other-window 1)
+    (setq enkan-dual-task-sub-input-window (selected-window))
+
+    ;; Place buffers in windows
+    (select-window enkan-dual-task-main-input-window)
+    (switch-to-buffer enkan-dual-task-main-input-buffer)
+
+    (select-window enkan-dual-task-sub-input-window)
+    (switch-to-buffer enkan-dual-task-sub-input-buffer)
+
+    (select-window enkan-dual-task-main-eat-window)
+    (switch-to-buffer enkan-dual-task-main-eat-buffer)
+
+    (select-window enkan-dual-task-sub-eat-window)
+    (switch-to-buffer enkan-dual-task-sub-eat-buffer)
+
+    ;; Return to main input window
+    (select-window enkan-dual-task-main-input-window)))
+
+  ;; Note: Window locking (window-dedicated-p) disabled to prevent eat scrolling issues
+  ;; Note: Face remapping removed to prevent minibuffer interaction issues
+
+;;; ========================================
+;;; Keybinding Help Functions
+;;; ========================================
+
+(defun enkan-dual-task-describe-keybindings ()
+  "Display keybindings active in dual task mode."
+  (interactive)
+  (with-output-to-temp-buffer "*Enkan Dual Task Keybindings*"
+    (princ "Enkan Dual Task Mode Keybindings\n")
+    (princ "=================================\n\n")
+
+    ;; Show base keybindings
+    (princ "Base Keybindings (inherited):\n")
+    (princ "------------------------------\n")
+    (when (boundp 'enkan-keybinding-definitions)
+      ;; Show non-overridden base bindings
+      (let ((overridden-keys (when (boundp 'enkan-dual-task-keybinding-overrides)
+                               (mapcar #'car enkan-dual-task-keybinding-overrides))))
+        (dolist (def enkan-keybinding-definitions)
+          (unless (member (car def) overridden-keys)
+            (princ (format "  %-15s - %s\n" (nth 0 def) (nth 2 def)))))))
+    (princ "\n")
+
+    ;; Show dual-task-specific overrides
+    (princ "Dual Task Mode Overrides:\n")
+    (princ "-------------------------\n")
+    (if (boundp 'enkan-dual-task-keybinding-overrides)
+        (princ (enkan-keybinding-format-description enkan-dual-task-keybinding-overrides))
+      ;; Fallback if constants not loaded
+      (princ "  C-t         - Switch between input windows\n"))
+
+    (princ "\nNote: Dual task mode overrides take precedence over base keybindings.\n")))
+
+;;; ========================================
+;;; Window Navigation Functions
+;;; ========================================
+
+(defun enkan-dual-task-switch-input ()
+  "Switch between main and sub input windows only.
+Avoids switching to eat windows."
+  (interactive)
+  (cond
+   ;; From main input -> go to sub input
+   ((and enkan-dual-task-main-input-window
+         (eq (selected-window) enkan-dual-task-main-input-window))
+    (when (window-live-p enkan-dual-task-sub-input-window)
+      (select-window enkan-dual-task-sub-input-window)))
+   ;; From sub input -> go to main input
+   ((and enkan-dual-task-sub-input-window
+         (eq (selected-window) enkan-dual-task-sub-input-window))
+    (when (window-live-p enkan-dual-task-main-input-window)
+      (select-window enkan-dual-task-main-input-window)))
+   ;; From eat windows -> go to main input
+   (t
+    (when (window-live-p enkan-dual-task-main-input-window)
+      (select-window enkan-dual-task-main-input-window)))))
+
+;;; ========================================
+;;; Window Lock/Unlock Functions (placeholder)
+;;; ========================================
+
+;; Note: Window locking disabled to prevent eat scrolling issues
+;; These functions are kept as placeholders for consistency
+
+(defun enkan-dual-task-lock-windows ()
+  "Lock windows to prevent opening other files in them.
+Currently disabled to prevent eat scrolling issues."
+  (interactive)
+  (message "Window locking is disabled to prevent eat scrolling issues."))
+
+(defun enkan-dual-task-unlock-windows ()
+  "Unlock windows to allow opening other files.
+Currently disabled to prevent eat scrolling issues."
+  (interactive)
+  (message "Window unlocking is disabled (windows are not locked)."))
+
+;;; ========================================
+;;; Remote eat Control Functions
+;;; ========================================
+
+(defun enkan-dual-task-send-escape ()
+  "Send ESC to the appropriate eat buffer from any window."
+  (interactive)
+  (enkan-dual-task--send-to-active-eat
+    'enkan-repl-send-escape "ESC"))
+
+(defun enkan-dual-task-send-1 ()
+  "Send choice 1 to the appropriate eat buffer from any window."
+  (interactive)
+  (enkan-dual-task--send-to-active-eat
+    'enkan-repl-send-1 "1"))
+
+(defun enkan-dual-task-send-2 ()
+  "Send choice 2 to the appropriate eat buffer from any window."
+  (interactive)
+  (enkan-dual-task--send-to-active-eat
+    'enkan-repl-send-2 "2"))
+
+(defun enkan-dual-task-send-3 ()
+  "Send choice 3 to the appropriate eat buffer from any window."
+  (interactive)
+  (enkan-dual-task--send-to-active-eat
+    'enkan-repl-send-3 "3"))
+
+(defun enkan-dual-task--send-to-active-eat (func msg)
+  "Helper function to send commands to the active eat buffer.
+FUNC is the function to call, MSG is the message to display.
+Sends to the eat buffer corresponding to the current input window."
+  (let ((target-eat-window
+         (cond
+          ;; If in main input window, send to main eat
+          ((and enkan-dual-task-main-input-window
+                (eq (selected-window) enkan-dual-task-main-input-window))
+           enkan-dual-task-main-eat-window)
+          ;; If in sub input window, send to sub eat
+          ((and enkan-dual-task-sub-input-window
+                (eq (selected-window) enkan-dual-task-sub-input-window))
+           enkan-dual-task-sub-eat-window)
+          ;; Default to main eat window
+          (t enkan-dual-task-main-eat-window))))
+    (if (and target-eat-window
+             (window-live-p target-eat-window))
+        (save-window-excursion
+          (select-window target-eat-window)
+          (funcall func)
+          (message "Sent %s to %s"
+                   msg
+                   (if (eq target-eat-window enkan-dual-task-main-eat-window)
+                       "main eat buffer"
+                     "sub eat buffer")))
+      (message "No eat window found. Run M-x enkan-dual-task-setup first.")))
+
+(defun enkan-dual-task-send-to-main ()
+  "Send text to main eat buffer explicitly."
+  (interactive)
+  (if (and enkan-dual-task-main-eat-window
+           (window-live-p enkan-dual-task-main-eat-window))
+      (save-window-excursion
+        (select-window enkan-dual-task-main-eat-window)
+        (message "Switched to main eat buffer for input"))
+    (message "Main eat window not found.")))
+
+(defun enkan-dual-task-send-to-sub ()
+  "Send text to sub eat buffer explicitly."
+  (interactive)
+  (if (and enkan-dual-task-sub-eat-window
+           (window-live-p enkan-dual-task-sub-eat-window))
+      (save-window-excursion
+        (select-window enkan-dual-task-sub-eat-window)
+        (message "Switched to sub eat buffer for input"))
+    (message "Sub eat window not found.")))
+
+;;; ========================================
+;;; Display Buffer Management
+;;; ========================================
+
+(defun enkan-dual-task-setup-display-buffer-rules ()
+  "Setup display-buffer rules for dual task layout.
+Currently minimal to avoid eat scrolling issues."
+  ;; Placeholder for future display-buffer rules
+  ;; Currently not adding advices to avoid interfering with eat
+  )
+
+(defun enkan-dual-task-display-buffer-advice (orig-fun buffer &rest args)
+  "Advice to handle buffer display in dual task layout.
+Currently minimal implementation to avoid interfering with dual task workflow."
+  (let ((buffer-name (buffer-name (get-buffer buffer))))
+    (cond
+     ;; Don't redirect eat buffers
+     ((string-match-p "^\\*enkan:" buffer-name)
+      (apply orig-fun buffer args))
+     ;; Don't redirect buffers that are already displayed
+     ((get-buffer-window buffer)
+      (apply orig-fun buffer args))
+     ;; Default behavior for dual task layout
+     (t (apply orig-fun buffer args)))))
+
+(defun enkan-dual-task-protect-window-advice (orig-fun &optional window)
+  "Prevent deletion of protected windows in dual task layout.
+Placeholder for consistency with 3pane."
+  ;; Currently no window protection needed for dual task
+  (apply orig-fun window))
+
+(defun enkan-dual-task-quit-window-advice (orig-fun &optional kill window)
+  "Handle quit-window in dual task layout.
+Placeholder for consistency with 3pane."
+  ;; Currently no special quit handling needed for dual task
+  (apply orig-fun kill window))
+
+;;; ========================================
+;;; Session Selection Functions
+;;; ========================================
+
+(defun enkan-dual-task-select-sessions ()
+  "Select two enkan-eat sessions interactively."
+  (let ((eat-buffers (enkan-dual-task-get-all-eat-buffers)))
+    (when (< (length eat-buffers) 2)
+      (error "Found only %d enkan session(s). Need at least 2" (length eat-buffers)))
+
+    ;; Select main session
+    (let* ((main-name (completing-read "Select MAIN enkan session: "
+                                        (mapcar #'buffer-name eat-buffers)
+                                        nil t))
+           (main-buffer (get-buffer main-name))
+           ;; Filter out selected main for sub selection
+           (remaining (remove main-buffer eat-buffers))
+           (sub-name (completing-read "Select SUB enkan session: "
+                                      (mapcar #'buffer-name remaining)
+                                      nil t))
+           (sub-buffer (get-buffer sub-name)))
+      (list main-buffer sub-buffer))))
+
+(defun enkan-dual-task-get-all-eat-buffers ()
+  "Get all enkan-eat buffers."
+  (seq-filter (lambda (buffer)
+                (string-match-p "^\\*enkan:" (buffer-name buffer)))
+              (buffer-list)))
+
+(defun enkan-dual-task-get-input-buffer-for-eat (eat-buffer)
+  "Get the input file buffer corresponding to EAT-BUFFER."
+  (when eat-buffer
+    (let* ((buffer-name (buffer-name eat-buffer))
+           ;; Extract directory from buffer name like "*enkan:/path/to/dir/*"
+           (dir (when (string-match "^\\*enkan:\\(.+\\)\\*$" buffer-name)
+                  (match-string 1 buffer-name)))
+           (input-file (when dir
+                        (enkan-repl--get-project-file-path dir))))
+      (when input-file
+        (if (file-exists-p input-file)
+            (find-file-noselect input-file)
+          ;; Create if doesn't exist
+          (enkan-repl--create-project-input-file dir)
+          (find-file-noselect input-file))))))
+
+;;; ========================================
+;;; Helper Functions
+;;; ========================================
+
+(defun enkan-dual-task-describe-layout ()
+  "Describe current dual task layout."
+  (interactive)
+  (with-output-to-temp-buffer "*Dual Task Layout*"
+    (princ "Dual Task Window Layout\n")
+    (princ "========================\n\n")
+
+    (princ "Main Task:\n")
+    (princ (format "  Input: %s\n"
+                   (if enkan-dual-task-main-input-buffer
+                       (buffer-name enkan-dual-task-main-input-buffer)
+                     "Not set")))
+    (princ (format "  Eat:   %s\n\n"
+                   (if enkan-dual-task-main-eat-buffer
+                       (buffer-name enkan-dual-task-main-eat-buffer)
+                     "Not set")))
+
+    (princ "Sub Task:\n")
+    (princ (format "  Input: %s\n"
+                   (if enkan-dual-task-sub-input-buffer
+                       (buffer-name enkan-dual-task-sub-input-buffer)
+                     "Not set")))
+    (princ (format "  Eat:   %s\n\n"
+                   (if enkan-dual-task-sub-eat-buffer
+                       (buffer-name enkan-dual-task-sub-eat-buffer)
+                     "Not set")))
+
+    (princ "Window Layout:\n")
+    (princ "  [Input Main] [Main Eat ] [Sub Eat  ]\n")
+    (princ "  [Input Sub ] [         ] [         ]\n")
+    (princ "     30%          40%         30%    \n\n")
+
+    (princ "Keybindings:\n")
+    (princ "  C-t - Switch between input windows\n")))
+
+(defun enkan-dual-task--track-buffer-history (new-buffer)
+  "Track buffer history for dual task windows.
+NEW-BUFFER is the buffer about to be displayed.
+Placeholder for consistency with 3pane - minimal implementation."
+  ;; Dual task doesn't need complex buffer history like 3pane
+  ;; This is just for structural consistency
+  nil)
+
+(defun enkan-dual-task--restore-previous-buffer ()
+  "Restore the previous buffer in dual task windows.
+Placeholder for consistency with 3pane - minimal implementation."
+  ;; Dual task doesn't need buffer restoration like 3pane
+  ;; This is just for structural consistency
+  (switch-to-buffer (other-buffer)))
+
+;;; ========================================
+;;; Cheat Sheet Integration
+;;; ========================================
+
+(defun enkan-dual-task-cheat-sheet-advice (orig-fun)
+  "Advice to add dual task commands to enkan-repl cheat sheet."
+  (if enkan-dual-task-mode
+      ;; When dual task mode is active, show combined cheat sheet
+      (progn
+        (unless (featurep 'enkan-repl-constants)
+          (require 'enkan-repl-constants nil t))
+        (let* ((original-candidates
+                (if (boundp 'enkan-repl-cheat-sheet-candidates)
+                    enkan-repl-cheat-sheet-candidates
+                  '()))
+               ;; Combine original and dual task candidates
+               (candidates (append original-candidates
+                                   enkan-dual-task-cheat-sheet-candidates)))
+          (let ((completion-extra-properties
+                 `(:annotation-function
+                   (lambda (candidate)
+                     (let ((description (alist-get candidate ',candidates
+                                                   nil nil #'string=)))
+                       (when description
+                         (format " — %s" description)))))))
+            (let ((selected-command
+                   (completing-read "enkan-repl & dual task commands: " candidates)))
+              (when selected-command
+                (call-interactively (intern selected-command)))))))
+    ;; When dual task mode is not active, use original function
+    (funcall orig-fun)))
+
+(defun enkan-dual-task-setup-cheat-sheet-advice ()
+  "Setup advice for cheat sheet integration."
+  (advice-add 'enkan-repl-cheat-sheet :around
+              #'enkan-dual-task-cheat-sheet-advice))
+
+(defun enkan-dual-task-remove-cheat-sheet-advice ()
+  "Remove advice for cheat sheet integration."
+  (advice-remove 'enkan-repl-cheat-sheet
+                 #'enkan-dual-task-cheat-sheet-advice))
+
+;;; ========================================
+;;; Provide
+;;; ========================================
+
+(provide 'dual-task-window-layout)
+
+;;; dual-task-window-layout.el ends here

--- a/examples/keybinding-constants.el
+++ b/examples/keybinding-constants.el
@@ -87,8 +87,22 @@ Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
   "Command definitions for 3pane mode cheat sheet.
 Each entry is (COMMAND DESCRIPTION).")
 
+(defconst enkan-dual-task-keybinding-overrides
+  '(("C-t" enkan-dual-task-switch-input "Switch between input windows" window-navigation))
+  "Keybinding overrides for dual task mode.
+Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
+
+(defconst enkan-dual-task-command-definitions
+  '((enkan-dual-task-setup "Setup dual task window layout")
+    (enkan-dual-task-reset "Reset dual task layout")
+    (enkan-dual-task-describe-layout "Show dual task layout status")
+    (enkan-dual-task-switch-input "Switch between input windows"))
+  "Command definitions for dual task mode.
+Each entry is (COMMAND DESCRIPTION).")
+
 (defconst enkan-mode-keybinding-overrides
-  `((enkan-simple-3pane-mode . ,enkan-simple-3pane-keybinding-overrides))
+  `((enkan-simple-3pane-mode . ,enkan-simple-3pane-keybinding-overrides)
+    (enkan-dual-task-mode . ,enkan-dual-task-keybinding-overrides))
   "Alist of modes to their keybinding override definitions.")
 
 ;;; ========================================

--- a/examples/keybinding-constants.el
+++ b/examples/keybinding-constants.el
@@ -1,0 +1,130 @@
+;;; keybinding-constants.el --- Keybinding definitions for enkan-repl -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; Keywords: convenience, tools
+
+;; This file is NOT part of GNU Emacs.
+
+;; This file provides centralized keybinding definitions for enkan-repl.
+;; All keybinding configurations should reference these constants.
+
+;;; Commentary:
+
+;; Centralized keybinding definitions to avoid duplication and ensure
+;; consistency across all enkan-repl components.
+;;
+;; Structure:
+;; - Each binding is defined as (KEY COMMAND DESCRIPTION CATEGORY)
+;; - Categories group related bindings
+;; - Mode-specific overrides are also defined here
+
+;;; Code:
+
+;;; ========================================
+;;; Base Keybinding Definitions
+;;; ========================================
+
+(defconst enkan-keybinding-definitions
+  '(;; Window Navigation
+     ("C-t" other-window-or-split "Other window or split" window-navigation)
+     ("M-t" other-window-or-split "Other window or split" window-navigation)
+     ("C-M-l" enkan-repl-setup-window-layout "Setup window layout" window-navigation)
+
+     ;; Text Sending
+     ("C-M-<return>" enkan-repl-send-region "Send region to REPL" text-sending)
+     ("C-M-i" enkan-repl-send-line "Send current line to REPL" text-sending)
+
+     ;; Quick Actions
+     ("<escape>" enkan-repl-send-escape "Send ESC to REPL" quick-actions)
+     ("C-M-1" enkan-repl-send-1 "Send 1 to REPL" quick-actions)
+     ("C-M-2" enkan-repl-send-2 "Send 2 to REPL" quick-actions)
+     ("C-M-3" enkan-repl-send-3 "Send 3 to REPL" quick-actions)
+     ("C-M-b" enkan-repl-recenter-bottom "Recenter at bottom" quick-actions)
+
+     ;; Project Management
+     ("C-M-s" enkan-repl-start-eat "Start eat session" project-management)
+     ("C-M-f" enkan-repl-finish-eat "Finish eat session" project-management)
+
+     ;; Help and Documentation
+     ("C-M-c" enkan-repl-cheat-sheet "Enkan cheat sheet" help))
+  "Base keybinding definitions for enkan-repl.
+Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
+
+(defconst enkan-keybinding-categories
+  '((window-navigation . "Window Navigation")
+     (text-sending . "Text Sending")
+     (quick-actions . "Quick Actions")
+     (project-management . "Project Management")
+     (help . "Help and Documentation"))
+  "Alist of category symbols to display names.")
+
+;;; ========================================
+;;; Mode-specific Override Definitions
+;;; ========================================
+
+(defconst enkan-simple-3pane-keybinding-overrides
+  '(("C-t" enkan-simple-3pane-other-window "Switch between input/misc windows" window-navigation)
+     ("<escape>" enkan-simple-3pane-send-escape "Send ESC to eat buffer" quick-actions)
+     ("C-M-1" enkan-simple-3pane-send-1 "Send 1 to eat buffer" quick-actions)
+     ("C-M-2" enkan-simple-3pane-send-2 "Send 2 to eat buffer" quick-actions)
+     ("C-M-3" enkan-simple-3pane-send-3 "Send 3 to eat buffer" quick-actions))
+  "Keybinding overrides for 3pane mode.
+Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
+
+(defconst enkan-mode-keybinding-overrides
+  `((enkan-simple-3pane-mode . ,enkan-simple-3pane-keybinding-overrides))
+  "Alist of modes to their keybinding override definitions.")
+
+;;; ========================================
+;;; Utility Functions
+;;; ========================================
+
+(defun enkan-keybinding-get-by-category (category &optional definitions)
+  "Get all keybindings in CATEGORY from DEFINITIONS.
+If DEFINITIONS is nil, use `enkan-keybinding-definitions'."
+  (let ((defs (or definitions enkan-keybinding-definitions)))
+    (seq-filter (lambda (def)
+                  (eq (nth 3 def) category))
+      defs)))
+
+(defun enkan-keybinding-get-categories (&optional definitions)
+  "Get all unique categories from DEFINITIONS.
+If DEFINITIONS is nil, use `enkan-keybinding-definitions'."
+  (let ((defs (or definitions enkan-keybinding-definitions)))
+    (seq-uniq (mapcar (lambda (def) (nth 3 def)) defs))))
+
+(defun enkan-keybinding-make-keymap (definitions)
+  "Create a keymap from DEFINITIONS."
+  (let ((map (make-sparse-keymap)))
+    (dolist (def definitions)
+      (let ((key (nth 0 def))
+             (command (nth 1 def)))
+        (define-key map (kbd key) command)))
+    map))
+
+(defun enkan-keybinding-format-description (definitions)
+  "Format DEFINITIONS as a human-readable string."
+  (let ((categories (enkan-keybinding-get-categories definitions))
+         (result ""))
+    (dolist (cat categories)
+      (let ((cat-name (or (cdr (assq cat enkan-keybinding-categories))
+                        (symbol-name cat)))
+             (bindings (enkan-keybinding-get-by-category cat definitions)))
+        (setq result (concat result cat-name ":\n"))
+        (dolist (binding bindings)
+          (setq result (concat result
+                         (format "  %-15s - %s\n"
+                           (nth 0 binding)
+                           (nth 2 binding)))))
+        (setq result (concat result "\n"))))
+    result))
+
+;;; ========================================
+;;; Provide
+;;; ========================================
+
+(provide 'keybinding-constants)
+
+;;; keybinding-constants.el ends here

--- a/examples/keybinding-constants.el
+++ b/examples/keybinding-constants.el
@@ -30,7 +30,7 @@
   '(;; Window Navigation
      ("C-t" other-window-or-split "Other window or split" window-navigation)
      ("M-t" other-window-or-split "Other window or split" window-navigation)
-     ("C-M-l" enkan-repl-setup-window-layout "Setup window layout" window-navigation)
+     ("C-M-l" enkan-repl-setup "Setup window layout" window-navigation)
 
      ;; Text Sending
      ("C-M-<return>" enkan-repl-send-region "Send region to REPL" text-sending)

--- a/examples/keybinding-constants.el
+++ b/examples/keybinding-constants.el
@@ -73,6 +73,20 @@ Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
   "Keybinding overrides for 3pane mode.
 Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
 
+(defconst enkan-simple-3pane-command-definitions
+  '((enkan-simple-3pane-setup "Setup 3-pane window layout")
+    (enkan-simple-3pane-reset "Reset 3-pane layout")
+    (enkan-simple-3pane-describe-keybindings "Show 3pane keybindings")
+    (enkan-simple-3pane-other-window "Switch between input/misc windows")
+    (enkan-simple-3pane-lock-windows "Lock input and eat windows")
+    (enkan-simple-3pane-unlock-windows "Unlock input and eat windows")
+    (enkan-simple-3pane-send-escape "Send ESC to eat buffer")
+    (enkan-simple-3pane-send-1 "Send 1 to eat buffer")
+    (enkan-simple-3pane-send-2 "Send 2 to eat buffer")
+    (enkan-simple-3pane-send-3 "Send 3 to eat buffer"))
+  "Command definitions for 3pane mode cheat sheet.
+Each entry is (COMMAND DESCRIPTION).")
+
 (defconst enkan-mode-keybinding-overrides
   `((enkan-simple-3pane-mode . ,enkan-simple-3pane-keybinding-overrides))
   "Alist of modes to their keybinding override definitions.")

--- a/examples/keybinding.el
+++ b/examples/keybinding.el
@@ -1,4 +1,4 @@
-;;; keybinding.el --- Sample keybindings for enkan-repl development -*- lexical-binding: t -*-
+;;; keybinding.el --- Base keybindings for enkan-repl development -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2025 phasetr
 
@@ -7,59 +7,28 @@
 
 ;; This file is NOT part of GNU Emacs.
 
-;; This file provides sample keybindings for enkan-repl development.
-;; These bindings can be used as a base configuration and partially
-;; overridden by 3pane mode.
+;; This file provides base keybindings for enkan-repl development.
+;; These bindings can be overridden by various window layout modes.
 
 ;;; Commentary:
 
-;; Sample keybinding configuration for enkan-repl development workflow.
-;; These bindings are designed to work well with AI-assisted development.
-;;
-;; The keybindings are organized into categories:
-;; - Window navigation
-;; - Buffer operations
-;; - Text sending to REPL
-;; - Development utilities
-;;
-;; When 3pane mode is active, some of these bindings will be overridden
-;; to provide 3pane-specific functionality.
+;; Base keybinding configuration for enkan-repl development workflow.
+;; All keybinding definitions are centralized in keybinding-constants.el
+;; to avoid duplication and ensure consistency.
 
 ;;; Code:
+
+(require 'keybinding-constants)
 
 ;;; ========================================
 ;;; Base Keymap Definition
 ;;; ========================================
 
 (defvar enkan-base-keymap
-  (let ((map (make-sparse-keymap)))
-    ;; Window Navigation
-    (define-key map (kbd "C-t") 'other-window-or-split)
-    (define-key map (kbd "M-t") 'other-window-or-split)
-    (define-key map (kdb "C-M-l") 'enkan-repl-setup-window-layout)
-
-    ;; Text Sending (Basic REPL interaction)
-    (define-key map (kbd "C-M-<return>") 'enkan-repl-send-region)
-    (define-key map (kbd "C-M-i") 'enkan-repl-send-line)
-
-    ;; Quick Actions (Will be enhanced by 3pane)
-    (define-key map (kbd "<escape>") 'enkan-repl-send-escape)
-    (define-key map (kbd "C-M-1") 'enkan-repl-send-1)
-    (define-key map (kbd "C-M-2") 'enkan-repl-send-2)
-    (define-key map (kbd "C-M-3") 'enkan-repl-send-3)
-    (define-key map (kbd "C-M-b") 'enkan-repl-recenter-bottom)
-
-    ;; Project Management
-    (define-key map (kbd "C-M-s") 'enkan-repl-start-eat)
-    (define-key map (kbd "C-M-s") 'enkan-repl-finish-eat)
-
-    ;; Help and Documentation
-    (define-key map (kbd "C-M-c") 'enkan-repl-cheat-sheet)
-
-    map)
+  (enkan-keybinding-make-keymap enkan-keybinding-definitions)
   "Base keymap for enkan-repl development.
-This keymap provides standard bindings that work in any context.
-Some bindings will be overridden when some mode is active.")
+This keymap is generated from `enkan-keybinding-definitions'.
+Some bindings may be overridden when specific window layout modes are active.")
 
 ;;; ========================================
 ;;; Keymap Installation Functions
@@ -70,21 +39,19 @@ Some bindings will be overridden when some mode is active.")
 This provides a consistent set of keybindings for enkan-repl development."
   (interactive)
   ;; Install keybindings globally
-  (dolist (binding (cdr enkan-base-keymap))
-    (when (consp binding)
-      (let ((key (car binding))
-             (command (cdr binding)))
-        (global-set-key key command))))
+  (dolist (def enkan-keybinding-definitions)
+    (let ((key (kbd (nth 0 def)))
+          (command (nth 1 def)))
+      (global-set-key key command)))
   (message "Enkan base keybindings installed globally."))
 
 (defun enkan-uninstall-base-keymap ()
   "Uninstall the base keymap globally."
   (interactive)
   ;; Remove keybindings
-  (dolist (binding (cdr enkan-base-keymap))
-    (when (consp binding)
-      (let ((key (car binding)))
-        (global-unset-key key))))
+  (dolist (def enkan-keybinding-definitions)
+    (let ((key (kbd (nth 0 def))))
+      (global-unset-key key)))
   (message "Enkan base keybindings removed."))
 
 ;;; ========================================
@@ -97,86 +64,63 @@ This provides a consistent set of keybindings for enkan-repl development."
   (with-output-to-temp-buffer "*Enkan Base Keybindings*"
     (princ "Enkan-REPL Base Keybindings\n")
     (princ "============================\n\n")
-
-    (princ "Window Navigation:\n")
-    (princ "  C-t         - Switch to other window (overridden in 3pane)\n")
-    (princ "  M-t         - Other window or split\n")
-    (princ "  C-x t       - Toggle split direction\n\n")
-
-    (princ "Buffer Operations:\n")
-    (princ "  C-c b r     - Revert buffer\n")
-    (princ "  C-c b k     - Kill current buffer\n")
-    (princ "  C-c b s     - Save buffer\n")
-    (princ "  C-c b S     - Save some buffers\n\n")
-
-    (princ "Text Sending:\n")
-    (princ "  C-c C-c     - Send entire buffer\n")
-    (princ "  C-c C-r     - Send region\n")
-    (princ "  C-c C-l     - Send current line\n")
-    (princ "  C-c C-e     - Send rest of buffer\n\n")
-
-    (princ "Quick Actions:\n")
-    (princ "  ESC         - Quit (overridden in 3pane to send ESC)\n")
-    (princ "  C-M-1       - Delete other windows (overridden in 3pane)\n")
-    (princ "  C-M-2       - Split window below (overridden in 3pane)\n")
-    (princ "  C-M-3       - Split window right (overridden in 3pane)\n\n")
-
-    (princ "Development Utilities:\n")
-    (princ "  C-c d f     - Find function definition\n")
-    (princ "  C-c d v     - Find variable definition\n")
-    (princ "  C-c d l     - Find library\n")
-    (princ "  C-c d d     - Describe function\n")
-    (princ "  C-c d k     - Describe key\n")
-    (princ "  C-c d m     - Describe mode\n\n")
-
-    (princ "File Navigation:\n")
-    (princ "  C-c f f     - Find file\n")
-    (princ "  C-c f r     - Recent files\n")
-    (princ "  C-c f d     - Open dired\n")
-    (princ "  C-c f j     - Jump to dired\n\n")
-
-    (princ "Search and Replace:\n")
-    (princ "  C-c s s     - Regexp search\n")
-    (princ "  C-c s r     - Query replace regexp\n")
-    (princ "  C-c s o     - Occur\n")
-    (princ "  C-c s g     - Grep\n\n")
-
-    (princ "Evaluation:\n")
-    (princ "  C-c e e     - Eval last sexp\n")
-    (princ "  C-c e b     - Eval buffer\n")
-    (princ "  C-c e r     - Eval region\n")
-    (princ "  C-c e f     - Eval defun\n\n")
-
-    (princ "Help and Documentation:\n")
-    (princ "  C-c h h     - Enkan cheat sheet\n")
-    (princ "  C-c h s     - Enkan status\n")
-    (princ "  C-c h d     - Toggle debug mode\n\n")
-
-    (princ "Project Management:\n")
-    (princ "  C-c p o     - Open project input file\n")
-    (princ "  C-c p s     - Start eat session\n")
-    (princ "  C-c p w     - Setup window layout\n\n")
-
-    (princ "Note: Bindings marked as 'overridden in 3pane' will have\n")
-    (princ "      different behavior when 3pane mode is active.\n")))
+    (princ (enkan-keybinding-format-description enkan-keybinding-definitions))
+    (princ "Note: These are base keybindings that apply globally.\n")
+    (princ "      Window layout modes (3pane, etc.) may override some bindings\n")
+    (princ "      to provide mode-specific functionality.\n")))
 
 ;;; ========================================
-;;; Integration with 3pane Mode
+;;; Mode Override Information
 ;;; ========================================
 
-(defun enkan-keybinding-3pane-compatibility-check ()
-  "Check which base keybindings will be overridden by 3pane mode."
+(defun enkan-keybinding-check-overrides (&optional mode)
+  "Check which base keybindings will be overridden by MODE.
+If MODE is nil, check all known modes."
+  (interactive (list (when current-prefix-arg
+                       (intern (completing-read "Mode: " 
+                                                (mapcar #'car enkan-mode-keybinding-overrides))))))
+  (let ((modes (if mode
+                   (list (cons mode (cdr (assq mode enkan-mode-keybinding-overrides))))
+                 enkan-mode-keybinding-overrides)))
+    (with-output-to-temp-buffer "*Keybinding Overrides*"
+      (princ "Keybinding Overrides by Window Layout Modes\n")
+      (princ "============================================\n\n")
+      (dolist (mode-entry modes)
+        (when mode-entry
+          (let ((mode-name (car mode-entry))
+                (overrides (cdr mode-entry)))
+            (princ (format "Mode: %s\n" mode-name))
+            (princ "----------------------------------------\n")
+            (when overrides
+              (princ (enkan-keybinding-format-description overrides)))
+            (princ "\n"))))
+      (princ "Note: These overrides only apply when the respective mode is active.\n"))))
+
+(defun enkan-keybinding-show-conflicts ()
+  "Show potential conflicts between base and override keybindings."
   (interactive)
-  (let ((overrides '(("C-t" . "Switch between input/misc windows")
-                      ("<escape>" . "Send ESC to eat buffer")
-                      ("C-M-1" . "Send 1 to eat buffer")
-                      ("C-M-2" . "Send 2 to eat buffer")
-                      ("C-M-3" . "Send 3 to eat buffer"))))
-    (with-output-to-temp-buffer "*3pane Keybinding Overrides*"
-      (princ "Keybindings that will be overridden in 3pane mode:\n")
-      (princ "==================================================\n\n")
-      (dolist (override overrides)
-        (princ (format "  %-10s -> %s\n" (car override) (cdr override)))))))
+  (let ((base-keys (mapcar #'car enkan-keybinding-definitions))
+        (conflicts '()))
+    (dolist (mode-entry enkan-mode-keybinding-overrides)
+      (let ((mode (car mode-entry))
+            (overrides (cdr mode-entry)))
+        (dolist (override overrides)
+          (let ((key (car override)))
+            (when (member key base-keys)
+              (push (list mode key
+                          (nth 2 (assoc key enkan-keybinding-definitions))
+                          (nth 2 override))
+                    conflicts))))))
+    (with-output-to-temp-buffer "*Keybinding Conflicts*"
+      (princ "Keybinding Conflicts (Base vs Mode Overrides)\n")
+      (princ "==============================================\n\n")
+      (if conflicts
+          (dolist (conflict (nreverse conflicts))
+            (princ (format "Mode: %s\n" (nth 0 conflict)))
+            (princ (format "  Key: %s\n" (nth 1 conflict)))
+            (princ (format "    Base:     %s\n" (nth 2 conflict)))
+            (princ (format "    Override: %s\n\n" (nth 3 conflict))))
+        (princ "No conflicts found.\n")))))
 
 ;;; ========================================
 ;;; Provide

--- a/examples/keybinding.el
+++ b/examples/keybinding.el
@@ -1,0 +1,187 @@
+;;; keybinding.el --- Sample keybindings for enkan-repl development -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; Keywords: convenience, tools
+
+;; This file is NOT part of GNU Emacs.
+
+;; This file provides sample keybindings for enkan-repl development.
+;; These bindings can be used as a base configuration and partially
+;; overridden by 3pane mode.
+
+;;; Commentary:
+
+;; Sample keybinding configuration for enkan-repl development workflow.
+;; These bindings are designed to work well with AI-assisted development.
+;;
+;; The keybindings are organized into categories:
+;; - Window navigation
+;; - Buffer operations
+;; - Text sending to REPL
+;; - Development utilities
+;;
+;; When 3pane mode is active, some of these bindings will be overridden
+;; to provide 3pane-specific functionality.
+
+;;; Code:
+
+;;; ========================================
+;;; Base Keymap Definition
+;;; ========================================
+
+(defvar enkan-base-keymap
+  (let ((map (make-sparse-keymap)))
+    ;; Window Navigation
+    (define-key map (kbd "C-t") 'other-window-or-split)
+    (define-key map (kbd "M-t") 'other-window-or-split)
+    (define-key map (kdb "C-M-l") 'enkan-repl-setup-window-layout)
+
+    ;; Text Sending (Basic REPL interaction)
+    (define-key map (kbd "C-M-<return>") 'enkan-repl-send-region)
+    (define-key map (kbd "C-M-i") 'enkan-repl-send-line)
+
+    ;; Quick Actions (Will be enhanced by 3pane)
+    (define-key map (kbd "<escape>") 'enkan-repl-send-escape)
+    (define-key map (kbd "C-M-1") 'enkan-repl-send-1)
+    (define-key map (kbd "C-M-2") 'enkan-repl-send-2)
+    (define-key map (kbd "C-M-3") 'enkan-repl-send-3)
+    (define-key map (kbd "C-M-b") 'enkan-repl-recenter-bottom)
+
+    ;; Project Management
+    (define-key map (kbd "C-M-s") 'enkan-repl-start-eat)
+    (define-key map (kbd "C-M-s") 'enkan-repl-finish-eat)
+
+    ;; Help and Documentation
+    (define-key map (kbd "C-M-c") 'enkan-repl-cheat-sheet)
+
+    map)
+  "Base keymap for enkan-repl development.
+This keymap provides standard bindings that work in any context.
+Some bindings will be overridden when some mode is active.")
+
+;;; ========================================
+;;; Keymap Installation Functions
+;;; ========================================
+
+(defun enkan-install-base-keymap ()
+  "Install the base keymap globally.
+This provides a consistent set of keybindings for enkan-repl development."
+  (interactive)
+  ;; Install keybindings globally
+  (dolist (binding (cdr enkan-base-keymap))
+    (when (consp binding)
+      (let ((key (car binding))
+             (command (cdr binding)))
+        (global-set-key key command))))
+  (message "Enkan base keybindings installed globally."))
+
+(defun enkan-uninstall-base-keymap ()
+  "Uninstall the base keymap globally."
+  (interactive)
+  ;; Remove keybindings
+  (dolist (binding (cdr enkan-base-keymap))
+    (when (consp binding)
+      (let ((key (car binding)))
+        (global-unset-key key))))
+  (message "Enkan base keybindings removed."))
+
+;;; ========================================
+;;; Helper Functions for Keybinding Management
+;;; ========================================
+
+(defun enkan-describe-base-keybindings ()
+  "Display a description of all base keybindings."
+  (interactive)
+  (with-output-to-temp-buffer "*Enkan Base Keybindings*"
+    (princ "Enkan-REPL Base Keybindings\n")
+    (princ "============================\n\n")
+
+    (princ "Window Navigation:\n")
+    (princ "  C-t         - Switch to other window (overridden in 3pane)\n")
+    (princ "  M-t         - Other window or split\n")
+    (princ "  C-x t       - Toggle split direction\n\n")
+
+    (princ "Buffer Operations:\n")
+    (princ "  C-c b r     - Revert buffer\n")
+    (princ "  C-c b k     - Kill current buffer\n")
+    (princ "  C-c b s     - Save buffer\n")
+    (princ "  C-c b S     - Save some buffers\n\n")
+
+    (princ "Text Sending:\n")
+    (princ "  C-c C-c     - Send entire buffer\n")
+    (princ "  C-c C-r     - Send region\n")
+    (princ "  C-c C-l     - Send current line\n")
+    (princ "  C-c C-e     - Send rest of buffer\n\n")
+
+    (princ "Quick Actions:\n")
+    (princ "  ESC         - Quit (overridden in 3pane to send ESC)\n")
+    (princ "  C-M-1       - Delete other windows (overridden in 3pane)\n")
+    (princ "  C-M-2       - Split window below (overridden in 3pane)\n")
+    (princ "  C-M-3       - Split window right (overridden in 3pane)\n\n")
+
+    (princ "Development Utilities:\n")
+    (princ "  C-c d f     - Find function definition\n")
+    (princ "  C-c d v     - Find variable definition\n")
+    (princ "  C-c d l     - Find library\n")
+    (princ "  C-c d d     - Describe function\n")
+    (princ "  C-c d k     - Describe key\n")
+    (princ "  C-c d m     - Describe mode\n\n")
+
+    (princ "File Navigation:\n")
+    (princ "  C-c f f     - Find file\n")
+    (princ "  C-c f r     - Recent files\n")
+    (princ "  C-c f d     - Open dired\n")
+    (princ "  C-c f j     - Jump to dired\n\n")
+
+    (princ "Search and Replace:\n")
+    (princ "  C-c s s     - Regexp search\n")
+    (princ "  C-c s r     - Query replace regexp\n")
+    (princ "  C-c s o     - Occur\n")
+    (princ "  C-c s g     - Grep\n\n")
+
+    (princ "Evaluation:\n")
+    (princ "  C-c e e     - Eval last sexp\n")
+    (princ "  C-c e b     - Eval buffer\n")
+    (princ "  C-c e r     - Eval region\n")
+    (princ "  C-c e f     - Eval defun\n\n")
+
+    (princ "Help and Documentation:\n")
+    (princ "  C-c h h     - Enkan cheat sheet\n")
+    (princ "  C-c h s     - Enkan status\n")
+    (princ "  C-c h d     - Toggle debug mode\n\n")
+
+    (princ "Project Management:\n")
+    (princ "  C-c p o     - Open project input file\n")
+    (princ "  C-c p s     - Start eat session\n")
+    (princ "  C-c p w     - Setup window layout\n\n")
+
+    (princ "Note: Bindings marked as 'overridden in 3pane' will have\n")
+    (princ "      different behavior when 3pane mode is active.\n")))
+
+;;; ========================================
+;;; Integration with 3pane Mode
+;;; ========================================
+
+(defun enkan-keybinding-3pane-compatibility-check ()
+  "Check which base keybindings will be overridden by 3pane mode."
+  (interactive)
+  (let ((overrides '(("C-t" . "Switch between input/misc windows")
+                      ("<escape>" . "Send ESC to eat buffer")
+                      ("C-M-1" . "Send 1 to eat buffer")
+                      ("C-M-2" . "Send 2 to eat buffer")
+                      ("C-M-3" . "Send 3 to eat buffer"))))
+    (with-output-to-temp-buffer "*3pane Keybinding Overrides*"
+      (princ "Keybindings that will be overridden in 3pane mode:\n")
+      (princ "==================================================\n\n")
+      (dolist (override overrides)
+        (princ (format "  %-10s -> %s\n" (car override) (cdr override)))))))
+
+;;; ========================================
+;;; Provide
+;;; ========================================
+
+(provide 'keybinding)
+
+;;; keybinding.el ends here

--- a/examples/keybinding.el
+++ b/examples/keybinding.el
@@ -77,7 +77,7 @@ This provides a consistent set of keybindings for enkan-repl development."
   "Check which base keybindings will be overridden by MODE.
 If MODE is nil, check all known modes."
   (interactive (list (when current-prefix-arg
-                       (intern (completing-read "Mode: " 
+                       (intern (completing-read "Mode: "
                                                 (mapcar #'car enkan-mode-keybinding-overrides))))))
   (let ((modes (if mode
                    (list (cons mode (cdr (assq mode enkan-mode-keybinding-overrides))))

--- a/examples/simple-3-pane-window-layout.el
+++ b/examples/simple-3-pane-window-layout.el
@@ -1,0 +1,284 @@
+;;; simple-3-pane-window-layout.el --- Simple 3-pane window layout for enkan-repl -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; Keywords: convenience, tools
+
+;; This file is NOT part of GNU Emacs.
+
+;; This file is an example configuration for enkan-repl.
+;; It provides a 3-pane window layout optimized for elisp development
+;; with Claude Code or other AI assistants.
+
+;;; Commentary:
+
+;; This example provides a 3-pane window layout configuration:
+;; - Left-top (60%): Input file buffer (locked, for composing prompts)
+;; - Left-bottom (40%): Miscellaneous files buffer (for viewing docs/tests)
+;; - Right (full height): eat terminal buffer (for AI interaction)
+;;
+;; Features:
+;; - Quick switching between input and misc windows only
+;; - eat buffer stays in semi-char mode without switching to it
+;; - Send escape/choices to eat from any buffer
+;; - Smaller text in eat buffer for better overview
+;;
+;; Usage:
+;; 1. Load this file:
+;;    (load-file "/path/to/enkan-repl/examples/simple-3-pane-window-layout.el")
+;;
+;; 2. Initialize layout:
+;;    M-x enkan-3pane-setup
+;;
+;; 3. Use keybindings:
+;;    C-c 3 s - Setup 3-pane layout
+;;    C-c 3 o - Switch between input/misc windows
+;;    C-c 3 l - Lock input buffer
+;;    C-c 3 u - Unlock input buffer
+;;    C-c 3 e - Send ESC to eat
+;;    C-c 3 1/2/3 - Send choice to eat
+
+;;; Code:
+
+(require 'enkan-repl)
+
+;;; Variables
+
+(defvar enkan-3pane-input-buffer nil
+  "Buffer for input file (prompts).")
+
+(defvar enkan-3pane-input-window nil
+  "Window for input file.")
+
+(defvar enkan-3pane-misc-window nil
+  "Window for miscellaneous files.")
+
+(defvar enkan-3pane-eat-window nil
+  "Window for eat terminal.")
+
+(defcustom enkan-3pane-eat-text-scale -1
+  "Text scale adjustment for eat buffer.
+Negative value makes text smaller."
+  :type 'integer
+  :group 'enkan-repl)
+
+(defcustom enkan-3pane-left-width-ratio 0.5
+  "Width ratio for left pane (0.0 to 1.0)."
+  :type 'float
+  :group 'enkan-repl)
+
+(defcustom enkan-3pane-input-height-ratio 0.6
+  "Height ratio for input window in left pane (0.0 to 1.0)."
+  :type 'float
+  :group 'enkan-repl)
+
+;;; Layout Management
+
+(defun enkan-3pane-setup ()
+  "Setup 3-pane window layout for elisp development.
+Left-top: Input buffer (60%)
+Left-bottom: Misc files (40%)
+Right: eat terminal (full height)"
+  (interactive)
+  ;; Save current buffer as input buffer
+  (setq enkan-3pane-input-buffer (current-buffer))
+  
+  ;; Delete other windows to start fresh
+  (delete-other-windows)
+  
+  ;; Setup left-top window (input)
+  (setq enkan-3pane-input-window (selected-window))
+  
+  ;; Create right pane for eat (50% width)
+  (let ((right-width (floor (* (window-width) 
+                                (- 1 enkan-3pane-left-width-ratio)))))
+    (split-window-horizontally (- right-width)))
+  
+  ;; Setup eat in right window
+  (other-window 1)
+  (setq enkan-3pane-eat-window (selected-window))
+  
+  ;; Start or switch to eat session
+  (if (get-buffer "*eat*")
+      (switch-to-buffer "*eat*")
+    (eat))
+  
+  ;; Adjust text scale in eat buffer
+  (text-scale-adjust enkan-3pane-eat-text-scale)
+  
+  ;; Go back to left pane and split vertically
+  (select-window enkan-3pane-input-window)
+  
+  ;; Create bottom window for misc files (40% of left pane)
+  ;; split-window-vertically takes the size of the top window
+  (let ((input-height (floor (* (window-height) 
+                                 enkan-3pane-input-height-ratio))))
+    (split-window-vertically input-height))
+  
+  ;; Setup misc window
+  (other-window 1)
+  (setq enkan-3pane-misc-window (selected-window))
+  
+  ;; Return to input window
+  (select-window enkan-3pane-input-window)
+  
+  ;; Lock input buffer
+  (enkan-3pane-lock-input-buffer)
+  
+  (message "3-pane layout initialized. Use C-c 3 o to switch windows."))
+
+(defun enkan-3pane-other-window ()
+  "Switch between input and misc windows only.
+Avoids switching to eat window."
+  (interactive)
+  (cond
+   ;; From input window -> go to misc
+   ((and enkan-3pane-input-window
+         (eq (selected-window) enkan-3pane-input-window))
+    (when (window-live-p enkan-3pane-misc-window)
+      (select-window enkan-3pane-misc-window)))
+   ;; From anywhere else -> go to input
+   (t
+    (when (window-live-p enkan-3pane-input-window)
+      (select-window enkan-3pane-input-window)))))
+
+(defun enkan-3pane-lock-input-buffer ()
+  "Lock input buffer to prevent opening other files in it."
+  (interactive)
+  (when (and enkan-3pane-input-buffer
+             (buffer-live-p enkan-3pane-input-buffer))
+    (let ((window (get-buffer-window enkan-3pane-input-buffer)))
+      (when window
+        (set-window-dedicated-p window t)
+        (message "Input buffer locked.")))))
+
+(defun enkan-3pane-unlock-input-buffer ()
+  "Unlock input buffer to allow opening other files."
+  (interactive)
+  (when (and enkan-3pane-input-buffer
+             (buffer-live-p enkan-3pane-input-buffer))
+    (let ((window (get-buffer-window enkan-3pane-input-buffer)))
+      (when window
+        (set-window-dedicated-p window nil)
+        (message "Input buffer unlocked.")))))
+
+;;; Remote eat Control
+
+(defun enkan-3pane-send-escape ()
+  "Send ESC to eat buffer from any window."
+  (interactive)
+  (if (and enkan-3pane-eat-window
+           (window-live-p enkan-3pane-eat-window))
+      (save-window-excursion
+        (select-window enkan-3pane-eat-window)
+        (enkan-repl-send-escape)
+        (message "Sent ESC to eat buffer"))
+    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+
+(defun enkan-3pane-send-1 ()
+  "Send choice 1 to eat buffer from any window."
+  (interactive)
+  (if (and enkan-3pane-eat-window
+           (window-live-p enkan-3pane-eat-window))
+      (save-window-excursion
+        (select-window enkan-3pane-eat-window)
+        (enkan-repl-send-1)
+        (message "Sent 1 to eat buffer"))
+    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+
+(defun enkan-3pane-send-2 ()
+  "Send choice 2 to eat buffer from any window."
+  (interactive)
+  (if (and enkan-3pane-eat-window
+           (window-live-p enkan-3pane-eat-window))
+      (save-window-excursion
+        (select-window enkan-3pane-eat-window)
+        (enkan-repl-send-2)
+        (message "Sent 2 to eat buffer"))
+    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+
+(defun enkan-3pane-send-3 ()
+  "Send choice 3 to eat buffer from any window."
+  (interactive)
+  (if (and enkan-3pane-eat-window
+           (window-live-p enkan-3pane-eat-window))
+      (save-window-excursion
+        (select-window enkan-3pane-eat-window)
+        (enkan-repl-send-3)
+        (message "Sent 3 to eat buffer"))
+    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+
+;;; Helper Functions
+
+(defun enkan-3pane-reset ()
+  "Reset all 3-pane related variables."
+  (interactive)
+  (setq enkan-3pane-input-buffer nil
+        enkan-3pane-input-window nil
+        enkan-3pane-misc-window nil
+        enkan-3pane-eat-window nil)
+  (message "3-pane layout reset."))
+
+(defun enkan-3pane-status ()
+  "Show status of 3-pane layout."
+  (interactive)
+  (message "3-pane status: Input:%s Misc:%s Eat:%s"
+           (if (and enkan-3pane-input-window 
+                    (window-live-p enkan-3pane-input-window))
+               "active" "inactive")
+           (if (and enkan-3pane-misc-window
+                    (window-live-p enkan-3pane-misc-window))
+               "active" "inactive")
+           (if (and enkan-3pane-eat-window
+                    (window-live-p enkan-3pane-eat-window))
+               "active" "inactive")))
+
+(defun enkan-3pane-balance-windows ()
+  "Rebalance windows to default ratios."
+  (interactive)
+  (when (and enkan-3pane-input-window
+             (window-live-p enkan-3pane-input-window))
+    (select-window enkan-3pane-input-window)
+    ;; Resize horizontally
+    (let ((total-width (frame-width))
+          (target-width (floor (* (frame-width) enkan-3pane-left-width-ratio))))
+      (window-resize nil (- target-width (window-width)) t))
+    ;; Resize vertically
+    (let ((left-height (window-height (frame-root-window)))
+          (target-height (floor (* (window-height (frame-root-window))
+                                   enkan-3pane-input-height-ratio))))
+      (window-resize nil (- target-height (window-height)) nil)))
+  (message "Windows rebalanced."))
+
+;;; Keybindings (optional - users can customize)
+
+(defvar enkan-3pane-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c 3 s") 'enkan-3pane-setup)
+    (define-key map (kbd "C-c 3 o") 'enkan-3pane-other-window)
+    (define-key map (kbd "C-c 3 l") 'enkan-3pane-lock-input-buffer)
+    (define-key map (kbd "C-c 3 u") 'enkan-3pane-unlock-input-buffer)
+    (define-key map (kbd "C-c 3 e") 'enkan-3pane-send-escape)
+    (define-key map (kbd "C-c 3 1") 'enkan-3pane-send-1)
+    (define-key map (kbd "C-c 3 2") 'enkan-3pane-send-2)
+    (define-key map (kbd "C-c 3 3") 'enkan-3pane-send-3)
+    (define-key map (kbd "C-c 3 r") 'enkan-3pane-reset)
+    (define-key map (kbd "C-c 3 b") 'enkan-3pane-balance-windows)
+    (define-key map (kbd "C-c 3 ?") 'enkan-3pane-status)
+    map)
+  "Keymap for 3-pane layout commands.")
+
+(define-minor-mode enkan-3pane-mode
+  "Minor mode for 3-pane window layout with enkan-repl."
+  :lighter " 3pane"
+  :keymap enkan-3pane-mode-map
+  :global t
+  (when enkan-3pane-mode
+    (message "enkan-3pane-mode enabled. C-c 3 s to setup layout.")))
+
+;;; Provide
+
+(provide 'simple-3-pane-window-layout)
+
+;;; simple-3-pane-window-layout.el ends here

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -114,7 +114,7 @@ Negative value makes text smaller."
   (message "3-pane layout initialized. Use C-c 3 o to switch windows."))
 
 (defun enkan-3pane-other-window ()
-p  "Switch between input and misc windows only.
+  "Switch between input and misc windows only.
 Avoids switching to eat window."
   (interactive)
   (cond

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -68,7 +68,7 @@ Negative value makes text smaller."
   :type 'float
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-misc-height-ratio 0.2
+(defcustom enkan-3pane-misc-height-ratio 0.8
   "Height ratio for misc window in right pane (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
@@ -91,14 +91,13 @@ Negative value makes text smaller."
                               (- 1 enkan-3pane-input-width-ratio)))))
     (split-window-horizontally (- right-width)))
 
-  ;; Move to right pane and split vertically
-  ;; (other-window 1)
+  ;; Move to left pane and split vertically
   (setq enkan-3pane-misc-left-down-window (selected-window))
   ;; Create bottom window for eat
   (let ((eat-height (floor (* (window-height)
                              (- 1 enkan-3pane-misc-height-ratio)))))
     (split-window-vertically (- eat-height)))
-  ;; Setup eat buffer in bottom window
+  ;; Setup eat buffer in right window
   (other-window 2)
   (setq enkan-3pane-eat-right-full-window (selected-window))
 

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -328,16 +328,16 @@ Avoids switching to eat window."
 ;;; Keybindings (optional - users can customize)
 
 (setq enkan-simple-3pane-mode-map
-      (let ((map (make-sparse-keymap)))
-        (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
-        (define-key map (kbd "M-t") 'other-window-or-split)
-        (define-key map (kbd "C-c 3 l") 'enkan-simple-3pane-lock-input-buffer)
-        (define-key map (kbd "C-c 3 u") 'enkan-simple-3pane-unlock-input-buffer)
-        (define-key map (kbd "Esc") 'enkan-simple-3pane-send-escape)
-        (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
-        (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
-        (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
-        map))
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
+    (define-key map (kbd "M-t") 'other-window-or-split)
+    (define-key map (kbd "C-c 3 l") 'enkan-simple-3pane-lock-input-buffer)
+    (define-key map (kbd "C-c 3 u") 'enkan-simple-3pane-unlock-input-buffer)
+    (define-key map (kbd "Esc") 'enkan-simple-3pane-send-escape)
+    (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
+    (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
+    (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
+    map))
 
 ;;; Provide
 

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -167,8 +167,8 @@ Negative value makes text smaller."
     (face-remap-add-relative 'default :height enkan-simple-3pane-eat-text-scale))
   ;; Return to input window
   (select-window enkan-simple-3pane-input-left-up-window)
-  ;; Lock input buffer
-  (enkan-simple-3pane-lock-input-buffer))
+  ;; Lock input and eat windows
+  (enkan-simple-3pane-lock-windows))
 
 ;;; Configuration Utilities
 
@@ -187,25 +187,47 @@ Avoids switching to eat window."
       (when (window-live-p enkan-simple-3pane-input-left-up-window)
         (select-window enkan-simple-3pane-input-left-up-window)))))
 
-(defun enkan-simple-3pane-lock-input-buffer ()
-  "Lock input buffer to prevent opening other files in it."
+(defun enkan-simple-3pane-lock-windows ()
+  "Lock input and eat windows to prevent opening other files in them."
   (interactive)
-  (when (and enkan-simple-3pane-input-buffer
-          (buffer-live-p enkan-simple-3pane-input-buffer))
-    (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
-      (when window
-        (set-window-dedicated-p window t)
-        (message "Input buffer locked.")))))
+  (let ((locked-windows '()))
+    ;; Lock input window
+    (when (and enkan-simple-3pane-input-buffer
+               (buffer-live-p enkan-simple-3pane-input-buffer))
+      (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
+        (when window
+          (set-window-dedicated-p window t)
+          (push "input" locked-windows))))
+    ;; Lock eat window
+    (when (and enkan-simple-3pane-eat-right-full-window
+               (window-live-p enkan-simple-3pane-eat-right-full-window))
+      (set-window-dedicated-p enkan-simple-3pane-eat-right-full-window t)
+      (push "eat" locked-windows))
+    ;; Report what was locked
+    (if locked-windows
+        (message "Locked windows: %s" (string-join (nreverse locked-windows) ", "))
+      (message "No windows to lock."))))
 
-(defun enkan-simple-3pane-unlock-input-buffer ()
-  "Unlock input buffer to allow opening other files."
+(defun enkan-simple-3pane-unlock-windows ()
+  "Unlock input and eat windows to allow opening other files."
   (interactive)
-  (when (and enkan-simple-3pane-input-buffer
-          (buffer-live-p enkan-simple-3pane-input-buffer))
-    (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
-      (when window
-        (set-window-dedicated-p window nil)
-        (message "Input buffer unlocked.")))))
+  (let ((unlocked-windows '()))
+    ;; Unlock input window
+    (when (and enkan-simple-3pane-input-buffer
+               (buffer-live-p enkan-simple-3pane-input-buffer))
+      (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
+        (when window
+          (set-window-dedicated-p window nil)
+          (push "input" unlocked-windows))))
+    ;; Unlock eat window
+    (when (and enkan-simple-3pane-eat-right-full-window
+               (window-live-p enkan-simple-3pane-eat-right-full-window))
+      (set-window-dedicated-p enkan-simple-3pane-eat-right-full-window nil)
+      (push "eat" unlocked-windows))
+    ;; Report what was unlocked
+    (if unlocked-windows
+        (message "Unlocked windows: %s" (string-join (nreverse unlocked-windows) ", "))
+      (message "No windows to unlock."))))
 
 ;;; Remote eat Control
 
@@ -350,8 +372,6 @@ Avoids switching to eat window."
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
     (define-key map (kbd "M-t") 'other-window-or-split)
-    (define-key map (kbd "C-c 3 l") 'enkan-simple-3pane-lock-input-buffer)
-    (define-key map (kbd "C-c 3 u") 'enkan-simple-3pane-unlock-input-buffer)
     (define-key map (kbd "Esc") 'enkan-simple-3pane-send-escape)
     (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
     (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -45,63 +45,77 @@
 
 ;;; Variables
 
-(defvar enkan-3pane-input-buffer nil
+(defvar enkan-simple-3pane-input-buffer nil
   "Buffer for input file (prompts).")
 
-(defvar enkan-3pane-input-left-up-window nil
+(defvar enkan-simple-3pane-input-left-up-window nil
   "Window for input file.")
 
-(defvar enkan-3pane-misc-left-down-window nil
+(defvar enkan-simple-3pane-misc-left-down-window nil
   "Window for miscellaneous files.")
 
-(defvar enkan-3pane-eat-right-full-window nil
+(defvar enkan-simple-3pane-eat-right-full-window nil
   "Window for eat terminal.")
 
-(defcustom enkan-3pane-eat-text-scale 0.85
+(defcustom enkan-simple-3pane-eat-text-scale 0.85
   "Text scale adjustment for eat buffer.
 Negative value makes text smaller."
   :type 'integer
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-input-width-ratio 0.6
+(defcustom enkan-simple-3pane-input-width-ratio 0.6
   "Width ratio for input window (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-input-height-ratio 0.55
+(defcustom enkan-simple-3pane-input-height-ratio 0.55
   "Height ratio for misc window in left pane (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
 
 ;;; Layout Management
 
-(defun enkan-3pane-setup ()
+(defun enkan-simple-3pane-setup ()
   "Setup 3-pane window layout for elisp development."
   (interactive)
+  ;; set up the window layout
+  (enkan-simple-3pane-window-setup)
+
+  ;; Enable the minor mode for keybindings
+  (unless enkan-simple-3pane-mode
+    (enkan-simple-3pane-mode 1))
+  ;; Setup display-buffer rules for misc window
+  (enkan-simple-3pane-setup-display-buffer-rules)
+  (message "3-pane layout initialized. Use C-t to switch windows."))
+
+;;; Window Management
+
+(defun enkan-simple-3pane-window-setup ()
+  "Set up fundamental 3-pane window layout"
   ;; Save current buffer as input buffer
-  (setq enkan-3pane-input-buffer (current-buffer))
+  (setq enkan-simple-3pane-input-buffer (current-buffer))
   ;; Delete other windows to start fresh
   (delete-other-windows)
 
   ;; Setup left window (input)
-  (setq enkan-3pane-input-left-up-window (selected-window))
+  (setq enkan-simple-3pane-input-left-up-window (selected-window))
 
   ;; Create right pane
   (let ((right-width (floor (* (window-width)
-                              (- 1 enkan-3pane-input-width-ratio)))))
+                              (- 1 enkan-simple-3pane-input-width-ratio)))))
     (split-window-horizontally (- right-width)))
 
   ;; Still in left-up window, split vertically
   ;; Create bottom window for misc
   (let ((top-height (floor (* (window-height)
-                               enkan-3pane-input-height-ratio))))
-    (setq enkan-3pane-misc-left-down-window (split-window-vertically top-height)))
+                               enkan-simple-3pane-input-height-ratio))))
+    (setq enkan-simple-3pane-misc-left-down-window (split-window-vertically top-height)))
   ;; Setup eat buffer in right window
   (other-window 2)
-  (setq enkan-3pane-eat-right-full-window (selected-window))
+  (setq enkan-simple-3pane-eat-right-full-window (selected-window))
 
   ;; Get or create enkan-repl buffer for current file's directory
-  (let* ((input-dir (file-name-directory (or (buffer-file-name enkan-3pane-input-buffer)
+  (let* ((input-dir (file-name-directory (or (buffer-file-name enkan-simple-3pane-input-buffer)
                                               default-directory)))
          (enkan-buffer-name (concat "*enkan:" input-dir "*"))
          (existing-buffer (get-buffer enkan-buffer-name)))
@@ -114,107 +128,103 @@ Negative value makes text smaller."
   ;; Ensure this is buffer-local
   (with-current-buffer (current-buffer)
     (setq-local face-remapping-alist nil)
-    (face-remap-add-relative 'default :height enkan-3pane-eat-text-scale))
+    (face-remap-add-relative 'default :height enkan-simple-3pane-eat-text-scale))
   ;; Return to input window
-  (select-window enkan-3pane-input-left-up-window)
+  (select-window enkan-simple-3pane-input-left-up-window)
   ;; Lock input buffer
-  (enkan-3pane-lock-input-buffer)
-  ;; Enable the minor mode for keybindings
-  (unless enkan-3pane-mode
-    (enkan-3pane-mode 1))
-  ;; Setup display-buffer rules for misc window
-  (enkan-3pane-setup-display-buffer-rules)
-  (message "3-pane layout initialized. Use C-t to switch windows."))
+  (enkan-simple-3pane-lock-input-buffer))
 
-(defun enkan-3pane-other-window ()
+;;; Configuration Utilities
+
+(defun enkan-simple-3pane-other-window ()
   "Switch between input and misc windows only.
 Avoids switching to eat window."
   (interactive)
   (cond
     ;; From input window -> go to misc
-    ((and enkan-3pane-input-left-up-window
-       (eq (selected-window) enkan-3pane-input-left-up-window))
-      (when (window-live-p enkan-3pane-misc-left-down-window)
-        (select-window enkan-3pane-misc-left-down-window)))
+    ((and enkan-simple-3pane-input-left-up-window
+       (eq (selected-window) enkan-simple-3pane-input-left-up-window))
+      (when (window-live-p enkan-simple-3pane-misc-left-down-window)
+        (select-window enkan-simple-3pane-misc-left-down-window)))
     ;; From anywhere else -> go to input
     (t
-      (when (window-live-p enkan-3pane-input-left-up-window)
-        (select-window enkan-3pane-input-left-up-window)))))
+      (when (window-live-p enkan-simple-3pane-input-left-up-window)
+        (select-window enkan-simple-3pane-input-left-up-window)))))
 
-(defun enkan-3pane-lock-input-buffer ()
+(defun enkan-simple-3pane-lock-input-buffer ()
   "Lock input buffer to prevent opening other files in it."
   (interactive)
-  (when (and enkan-3pane-input-buffer
-          (buffer-live-p enkan-3pane-input-buffer))
-    (let ((window (get-buffer-window enkan-3pane-input-buffer)))
+  (when (and enkan-simple-3pane-input-buffer
+          (buffer-live-p enkan-simple-3pane-input-buffer))
+    (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
       (when window
         (set-window-dedicated-p window t)
         (message "Input buffer locked.")))))
 
-(defun enkan-3pane-unlock-input-buffer ()
+(defun enkan-simple-3pane-unlock-input-buffer ()
   "Unlock input buffer to allow opening other files."
   (interactive)
-  (when (and enkan-3pane-input-buffer
-          (buffer-live-p enkan-3pane-input-buffer))
-    (let ((window (get-buffer-window enkan-3pane-input-buffer)))
+  (when (and enkan-simple-3pane-input-buffer
+          (buffer-live-p enkan-simple-3pane-input-buffer))
+    (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
       (when window
         (set-window-dedicated-p window nil)
         (message "Input buffer unlocked.")))))
 
 ;;; Remote eat Control
 
-(defun enkan-3pane-send-escape ()
+(defun enkan-simple-3pane-send-escape ()
   "Send ESC to eat buffer from any window."
   (interactive)
-  (if (and enkan-3pane-eat-right-full-window
-        (window-live-p enkan-3pane-eat-right-full-window))
+  (if (and enkan-simple-3pane-eat-right-full-window
+        (window-live-p enkan-simple-3pane-eat-right-full-window))
     (save-window-excursion
-      (select-window enkan-3pane-eat-right-full-window)
+      (select-window enkan-simple-3pane-eat-right-full-window)
       (enkan-repl-send-escape)
       (message "Sent ESC to eat buffer"))
-    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
 
-(defun enkan-3pane-send-1 ()
+(defun enkan-simple-3pane-send-1 ()
   "Send choice 1 to eat buffer from any window."
   (interactive)
-  (if (and enkan-3pane-eat-right-full-window
-        (window-live-p enkan-3pane-eat-right-full-window))
+  (if (and enkan-simple-3pane-eat-right-full-window
+        (window-live-p enkan-simple-3pane-eat-right-full-window))
     (save-window-excursion
-      (select-window enkan-3pane-eat-right-full-window)
+      (select-window enkan-simple-3pane-eat-right-full-window)
       (enkan-repl-send-1)
       (message "Sent 1 to eat buffer"))
-    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
 
-(defun enkan-3pane-send-2 ()
+(defun enkan-simple-3pane-send-2 ()
   "Send choice 2 to eat buffer from any window."
   (interactive)
-  (if (and enkan-3pane-eat-right-full-window
-        (window-live-p enkan-3pane-eat-right-full-window))
+  (if (and enkan-simple-3pane-eat-right-full-window
+        (window-live-p enkan-simple-3pane-eat-right-full-window))
     (save-window-excursion
-      (select-window enkan-3pane-eat-right-full-window)
+      (select-window enkan-simple-3pane-eat-right-full-window)
       (enkan-repl-send-2)
       (message "Sent 2 to eat buffer"))
-    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
 
-(defun enkan-3pane-send-3 ()
+(defun enkan-simple-3pane-send-3 ()
   "Send choice 3 to eat buffer from any window."
   (interactive)
-  (if (and enkan-3pane-eat-right-full-window
-        (window-live-p enkan-3pane-eat-right-full-window))
+  (if (and enkan-simple-3pane-eat-right-full-window
+        (window-live-p enkan-simple-3pane-eat-right-full-window))
     (save-window-excursion
-      (select-window enkan-3pane-eat-right-full-window)
+      (select-window enkan-simple-3pane-eat-right-full-window)
       (enkan-repl-send-3)
       (message "Sent 3 to eat buffer"))
-    (message "No eat window found. Run M-x enkan-3pane-setup first.")))
+    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
 
 ;;; Helper Functions
 
-(defun enkan-3pane-setup-display-buffer-rules ()
+(defun enkan-simple-3pane-setup-display-buffer-rules ()
   "Setup display-buffer rules to force misc buffers to left-down window."
   ;; Override the default display-buffer function
-  (advice-add 'display-buffer :around #'enkan-3pane-display-buffer-advice))
+  (advice-add 'display-buffer :around #'enkan-simple-3pane-display-buffer-advice))
 
-(defun enkan-3pane-display-buffer-advice (orig-fun buffer &rest args)
+(defun enkan-simple-3pane-display-buffer-advice (orig-fun buffer &rest args)
   "Advice to redirect buffers to misc window when appropriate."
   (let ((buffer-name (buffer-name (get-buffer buffer))))
     (cond
@@ -225,70 +235,55 @@ Avoids switching to eat window."
      ((get-buffer-window buffer)
       (apply orig-fun buffer args))
      ;; Redirect everything else to misc window if it exists
-     ((and enkan-3pane-misc-left-down-window
-           (window-live-p enkan-3pane-misc-left-down-window)
+     ((and enkan-simple-3pane-misc-left-down-window
+           (window-live-p enkan-simple-3pane-misc-left-down-window)
            ;; But not if we're in the input window editing a file
-           (not (and (eq (selected-window) enkan-3pane-input-left-up-window)
+           (not (and (eq (selected-window) enkan-simple-3pane-input-left-up-window)
                      (buffer-file-name buffer))))
-      (set-window-buffer enkan-3pane-misc-left-down-window buffer)
-      (select-window enkan-3pane-misc-left-down-window)
-      enkan-3pane-misc-left-down-window)
+      (set-window-buffer enkan-simple-3pane-misc-left-down-window buffer)
+      (select-window enkan-simple-3pane-misc-left-down-window)
+      enkan-simple-3pane-misc-left-down-window)
      ;; Default behavior
      (t (apply orig-fun buffer args)))))
 
-(defun enkan-3pane-reset ()
+(defun enkan-simple-3pane-reset ()
   "Reset all 3-pane related variables."
   (interactive)
-  (setq enkan-3pane-input-buffer nil
-    enkan-3pane-input-left-up-window nil
-    enkan-3pane-misc-left-down-window nil
-    enkan-3pane-eat-right-full-window nil)
+  (setq enkan-simple-3pane-input-buffer nil
+    enkan-simple-3pane-input-left-up-window nil
+    enkan-simple-3pane-misc-left-down-window nil
+    enkan-simple-3pane-eat-right-full-window nil)
   ;; Remove display-buffer advice
-  (advice-remove 'display-buffer #'enkan-3pane-display-buffer-advice)
+  (advice-remove 'display-buffer #'enkan-simple-3pane-display-buffer-advice)
   (message "3-pane layout reset."))
-
-(defun enkan-3pane-status ()
-  "Show status of 3-pane layout."
-  (interactive)
-  (message "3-pane status: Input:%s Misc:%s Eat:%s"
-    (if (and enkan-3pane-input-left-up-window
-          (window-live-p enkan-3pane-input-left-up-window))
-      "active" "inactive")
-    (if (and enkan-3pane-misc-left-down-window
-          (window-live-p enkan-3pane-misc-left-down-window))
-      "active" "inactive")
-    (if (and enkan-3pane-eat-right-full-window
-          (window-live-p enkan-3pane-eat-right-full-window))
-      "active" "inactive")))
 
 ;;; Keybindings (optional - users can customize)
 
-(defvar enkan-3pane-mode-map nil
+(defvar enkan-simple-3pane-mode-map nil
   "Keymap for 3-pane layout commands.")
 
-(setq enkan-3pane-mode-map
+(setq enkan-simple-3pane-mode-map
       (let ((map (make-sparse-keymap)))
-        (define-key map (kbd "C-c 3 s") 'enkan-3pane-setup)
-        (define-key map (kbd "C-t") 'enkan-3pane-other-window)
+        (define-key map (kbd "C-c 3 s") 'enkan-simple-3pane-setup)
+        (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
         (define-key map (kbd "M-t") 'other-window-or-split)
-        (define-key map (kbd "C-c 3 l") 'enkan-3pane-lock-input-buffer)
-        (define-key map (kbd "C-c 3 u") 'enkan-3pane-unlock-input-buffer)
-        (define-key map (kbd "C-c 3 e") 'enkan-3pane-send-escape)
-        (define-key map (kbd "C-c 3 1") 'enkan-3pane-send-1)
-        (define-key map (kbd "C-c 3 2") 'enkan-3pane-send-2)
-        (define-key map (kbd "C-c 3 3") 'enkan-3pane-send-3)
-        (define-key map (kbd "C-c 3 r") 'enkan-3pane-reset)
-        (define-key map (kbd "C-c 3 ?") 'enkan-3pane-status)
+        (define-key map (kbd "C-c 3 l") 'enkan-simple-3pane-lock-input-buffer)
+        (define-key map (kbd "C-c 3 u") 'enkan-simple-3pane-unlock-input-buffer)
+        (define-key map (kbd "C-c 3 e") 'enkan-simple-3pane-send-escape)
+        (define-key map (kbd "C-c 3 1") 'enkan-simple-3pane-send-1)
+        (define-key map (kbd "C-c 3 2") 'enkan-simple-3pane-send-2)
+        (define-key map (kbd "C-c 3 3") 'enkan-simple-3pane-send-3)
+        (define-key map (kbd "C-c 3 r") 'enkan-simple-3pane-reset)
         map))
 
-(define-minor-mode enkan-3pane-mode
+(define-minor-mode enkan-simple-3pane-mode
   "Minor mode for 3-pane window layout with enkan-repl."
   :lighter " 3pane"
-  :keymap enkan-3pane-mode-map  ; This is critical - must specify the keymap
+  :keymap enkan-simple-3pane-mode-map  ; This is critical - must specify the keymap
   :global t
-  (if enkan-3pane-mode
-    (message "enkan-3pane-mode enabled. C-t to switch windows.")
-    (message "enkan-3pane-mode disabled.")))
+  (if enkan-simple-3pane-mode
+    (message "enkan-simple-3pane-mode enabled. C-t to switch windows.")
+    (message "enkan-simple-3pane-mode disabled.")))
 
 ;;; Provide
 

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -42,6 +42,19 @@
 
 (require 'enkan-repl)
 
+;; Load keybinding definitions and base keymap
+(let ((constants-file (expand-file-name "keybinding-constants.el" 
+                                         (file-name-directory load-file-name)))
+      (keybinding-file (expand-file-name "keybinding.el" 
+                                          (file-name-directory load-file-name))))
+  (when (file-exists-p constants-file)
+    (load constants-file))
+  (when (file-exists-p keybinding-file)
+    (load keybinding-file)
+    ;; Install base keybindings as default
+    (when (fboundp 'enkan-install-base-keymap)
+      (enkan-install-base-keymap))))
+
 ;;; ========================================
 ;;; Customization Variables
 ;;; ========================================
@@ -105,14 +118,19 @@ This is set automatically when enkan-simple-3pane-setup is called.")
 ;;; ========================================
 
 (setq enkan-simple-3pane-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
-    (define-key map (kbd "M-t") 'other-window-or-split)
-    (define-key map (kbd "<escape>") 'enkan-simple-3pane-send-escape)
-    (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
-    (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
-    (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
-    map))
+  (if (boundp 'enkan-simple-3pane-keybinding-overrides)
+      ;; Use centralized definitions if available
+      (enkan-keybinding-make-keymap enkan-simple-3pane-keybinding-overrides)
+    ;; Fallback to manual definition
+    (let ((map (make-sparse-keymap)))
+      ;; These bindings override the base keybindings when 3pane mode is active
+      (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
+      (define-key map (kbd "M-t") 'other-window-or-split)
+      (define-key map (kbd "<escape>") 'enkan-simple-3pane-send-escape)
+      (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
+      (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
+      (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
+      map)))
 
 ;;; ========================================
 ;;; Minor Mode Definition

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -63,12 +63,12 @@ Negative value makes text smaller."
   :type 'integer
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-input-width-ratio 0.6
+(defcustom enkan-3pane-input-width-ratio 0.8
   "Width ratio for input window (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-misc-height-ratio 0.4
+(defcustom enkan-3pane-misc-height-ratio 0.2
   "Height ratio for misc window in right pane (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
@@ -92,7 +92,7 @@ Negative value makes text smaller."
     (split-window-horizontally (- right-width)))
 
   ;; Move to right pane and split vertically
-  (other-window 1)
+  ;; (other-window 1)
   (setq enkan-3pane-misc-left-down-window (selected-window))
   ;; Create bottom window for eat
   (let ((eat-height (floor (* (window-height)

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -91,12 +91,11 @@ Negative value makes text smaller."
                               (- 1 enkan-3pane-input-width-ratio)))))
     (split-window-horizontally (- right-width)))
 
-  ;; Move to left pane and split vertically
-  (setq enkan-3pane-misc-left-down-window (selected-window))
-  ;; Create bottom window for eat
-  (let ((eat-height (floor (* (window-height)
-                             (- 1 enkan-3pane-input-height-ratio)))))
-    (split-window-vertically (- eat-height)))
+  ;; Still in left-up window, split vertically
+  ;; Create bottom window for misc
+  (let ((top-height (floor (* (window-height)
+                               enkan-3pane-input-height-ratio))))
+    (setq enkan-3pane-misc-left-down-window (split-window-vertically top-height)))
   ;; Setup eat buffer in right window
   (other-window 2)
   (setq enkan-3pane-eat-right-full-window (selected-window))
@@ -229,7 +228,7 @@ Avoids switching to eat window."
 (defvar enkan-3pane-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c 3 s") 'enkan-3pane-setup)
-    (define-key map (kbd "M-t") 'enkan-3pane-other-window)
+    (define-key map (kbd "C-t") 'enkan-3pane-other-window)
     (define-key map (kbd "C-c 3 l") 'enkan-3pane-lock-input-buffer)
     (define-key map (kbd "C-c 3 u") 'enkan-3pane-unlock-input-buffer)
     (define-key map (kbd "C-c 3 e") 'enkan-3pane-send-escape)

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -57,7 +57,7 @@
 (defvar enkan-3pane-eat-right-full-window nil
   "Window for eat terminal.")
 
-(defcustom enkan-3pane-eat-text-scale -1
+(defcustom enkan-3pane-eat-text-scale -0.5
   "Text scale adjustment for eat buffer.
 Negative value makes text smaller."
   :type 'integer
@@ -99,8 +99,9 @@ Negative value makes text smaller."
                              (- 1 enkan-3pane-misc-height-ratio)))))
     (split-window-vertically (- eat-height)))
   ;; Setup eat buffer in bottom window
-  (other-window 1)
+  (other-window 2)
   (setq enkan-3pane-eat-right-full-window (selected-window))
+
   ;; Start or switch to eat session
   (if (get-buffer "*eat*")
     (switch-to-buffer "*eat*")

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -231,28 +231,31 @@ Avoids switching to eat window."
 
 ;;; Keybindings (optional - users can customize)
 
-(defvar enkan-3pane-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c 3 s") 'enkan-3pane-setup)
-    (define-key map (kbd "C-t") 'enkan-3pane-other-window)
-    (define-key map (kbd "C-c 3 l") 'enkan-3pane-lock-input-buffer)
-    (define-key map (kbd "C-c 3 u") 'enkan-3pane-unlock-input-buffer)
-    (define-key map (kbd "C-c 3 e") 'enkan-3pane-send-escape)
-    (define-key map (kbd "C-c 3 1") 'enkan-3pane-send-1)
-    (define-key map (kbd "C-c 3 2") 'enkan-3pane-send-2)
-    (define-key map (kbd "C-c 3 3") 'enkan-3pane-send-3)
-    (define-key map (kbd "C-c 3 r") 'enkan-3pane-reset)
-    (define-key map (kbd "C-c 3 ?") 'enkan-3pane-status)
-    map)
+(defvar enkan-3pane-mode-map nil
   "Keymap for 3-pane layout commands.")
+
+(setq enkan-3pane-mode-map
+      (let ((map (make-sparse-keymap)))
+        (define-key map (kbd "C-c 3 s") 'enkan-3pane-setup)
+        (define-key map (kbd "C-t") 'enkan-3pane-other-window)
+        (define-key map (kbd "C-c 3 l") 'enkan-3pane-lock-input-buffer)
+        (define-key map (kbd "C-c 3 u") 'enkan-3pane-unlock-input-buffer)
+        (define-key map (kbd "C-c 3 e") 'enkan-3pane-send-escape)
+        (define-key map (kbd "C-c 3 1") 'enkan-3pane-send-1)
+        (define-key map (kbd "C-c 3 2") 'enkan-3pane-send-2)
+        (define-key map (kbd "C-c 3 3") 'enkan-3pane-send-3)
+        (define-key map (kbd "C-c 3 r") 'enkan-3pane-reset)
+        (define-key map (kbd "C-c 3 ?") 'enkan-3pane-status)
+        map))
 
 (define-minor-mode enkan-3pane-mode
   "Minor mode for 3-pane window layout with enkan-repl."
   :lighter " 3pane"
-  :keymap enkan-3pane-mode-map
+  :keymap enkan-3pane-mode-map  ; This is critical - must specify the keymap
   :global t
-  (when enkan-3pane-mode
-    (message "enkan-3pane-mode enabled. C-c 3 s to setup layout.")))
+  (if enkan-3pane-mode
+      (message "enkan-3pane-mode enabled. C-t to switch windows.")
+    (message "enkan-3pane-mode disabled.")))
 
 ;;; Provide
 

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -14,45 +14,57 @@
 ;;; Commentary:
 
 ;; This example provides a 3-pane window layout configuration:
-;; - Left: Input file buffer (locked, for composing prompts)
-;; - Right-top: Miscellaneous files buffer (for viewing docs/tests)
-;; - Right-bottom: eat terminal buffer (for AI interaction)
+;; - Left-top: Input file buffer (60% width, 55% height, locked)
+;; - Left-bottom: Miscellaneous files buffer (60% width, 45% height)
+;; - Right: eat terminal buffer (40% width, full height, locked)
 ;;
 ;; Features:
-;; - Quick switching between input and misc windows only
-;; - eat buffer stays in semi-char mode without switching to it
+;; - Quick switching between input and misc windows (C-t)
+;; - eat buffer stays in right pane without switching to it
 ;; - Send escape/choices to eat from any buffer
 ;; - Smaller text in eat buffer for better overview
+;; - Window protection and buffer history management
+;; - Cheat-sheet integration with enkan-repl
 ;;
 ;; Usage:
 ;; 1. Load this file:
 ;;    (load-file "/path/to/enkan-repl/examples/simple-3-pane-window-layout.el")
 ;;
 ;; 2. Initialize layout:
-;;    M-x enkan-3pane-setup
+;;    M-x enkan-simple-3pane-setup
 ;;
 ;; 3. Use keybindings:
-;;    C-c 3 s - Setup 3-pane layout
-;;    C-c 3 o - Switch between input/misc windows
-;;    C-c 3 l - Lock input buffer
-;;    C-c 3 u - Unlock input buffer
-;;    C-c 3 e - Send ESC to eat
-;;    C-c 3 1/2/3 - Send choice to eat
+;;    C-t - Switch between input/misc windows
+;;    Esc - Send ESC to eat
+;;    C-M-1/2/3 - Send choice to eat
 
 ;;; Code:
 
 (require 'enkan-repl)
 
-;;; Variables
+;;; ========================================
+;;; Customization Variables
+;;; ========================================
 
-(defvar enkan-simple-3pane-cheat-sheet-candidates
-  '(("enkan-simple-3pane-setup" . "Setup 3-pane window layout")
-     ("enkan-simple-3pane-send-escape" . "Send ESC to eat buffer (Esc)")
-     ("enkan-simple-3pane-send-1" . "Send 1 to eat buffer (C-M-1)")
-     ("enkan-simple-3pane-send-2" . "Send 2 to eat buffer (C-M-2)")
-     ("enkan-simple-3pane-send-3" . "Send 3 to eat buffer (C-M-3)"))
-  "Additional commands for 3-pane layout to add to cheat sheet.
-Only important actions.")
+(defcustom enkan-simple-3pane-eat-text-scale 0.85
+  "Text scale adjustment for eat buffer.
+Negative value makes text smaller."
+  :type 'float
+  :group 'enkan-repl)
+
+(defcustom enkan-simple-3pane-input-width-ratio 0.6
+  "Width ratio for input window (0.0 to 1.0)."
+  :type 'float
+  :group 'enkan-repl)
+
+(defcustom enkan-simple-3pane-input-height-ratio 0.55
+  "Height ratio for input window in left pane (0.0 to 1.0)."
+  :type 'float
+  :group 'enkan-repl)
+
+;;; ========================================
+;;; Internal Variables
+;;; ========================================
 
 (defvar enkan-simple-3pane-input-file-path nil
   "Path to the input file determined from the current directory.
@@ -76,67 +88,103 @@ This is set automatically when enkan-simple-3pane-setup is called.")
 (defvar enkan-simple-3pane-mode-map nil
   "Keymap for 3-pane layout commands.")
 
-(defcustom enkan-simple-3pane-eat-text-scale 0.85
-  "Text scale adjustment for eat buffer.
-Negative value makes text smaller."
-  :type 'integer
-  :group 'enkan-repl)
+(defvar enkan-simple-3pane-cheat-sheet-candidates
+  '(("enkan-simple-3pane-setup" . "Setup 3-pane window layout")
+     ("enkan-simple-3pane-reset" . "Reset 3-pane layout")
+     ("enkan-simple-3pane-other-window" . "Switch between input/misc windows (C-t)")
+     ("enkan-simple-3pane-lock-windows" . "Lock input and eat windows")
+     ("enkan-simple-3pane-unlock-windows" . "Unlock input and eat windows")
+     ("enkan-simple-3pane-send-escape" . "Send ESC to eat buffer (Esc)")
+     ("enkan-simple-3pane-send-1" . "Send 1 to eat buffer (C-M-1)")
+     ("enkan-simple-3pane-send-2" . "Send 2 to eat buffer (C-M-2)")
+     ("enkan-simple-3pane-send-3" . "Send 3 to eat buffer (C-M-3)"))
+  "Additional commands for 3-pane layout to add to cheat sheet.")
 
-(defcustom enkan-simple-3pane-input-width-ratio 0.6
-  "Width ratio for input window (0.0 to 1.0)."
-  :type 'float
-  :group 'enkan-repl)
+;;; ========================================
+;;; Keymap Definition
+;;; ========================================
 
-(defcustom enkan-simple-3pane-input-height-ratio 0.55
-  "Height ratio for misc window in left pane (0.0 to 1.0)."
-  :type 'float
-  :group 'enkan-repl)
+(setq enkan-simple-3pane-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
+    (define-key map (kbd "M-t") 'other-window-or-split)
+    (define-key map (kbd "<escape>") 'enkan-simple-3pane-send-escape)
+    (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
+    (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
+    (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
+    map))
 
-;;; minor mode
+;;; ========================================
+;;; Minor Mode Definition
+;;; ========================================
 
 (define-minor-mode enkan-simple-3pane-mode
   "Minor mode for 3-pane window layout with enkan-repl."
   :lighter " 3pane"
-  :keymap enkan-simple-3pane-mode-map ; This is critical - must specify the keymap
+  :keymap enkan-simple-3pane-mode-map
   :global t
   (if enkan-simple-3pane-mode
-    (message "enkan-simple-3pane-mode enabled. C-t to switch windows.")
-    (message "enkan-simple-3pane-mode disabled.")))
+    (progn
+      (enkan-simple-3pane-setup-cheat-sheet-advice)
+      (message "enkan-simple-3pane-mode enabled. C-t to switch windows."))
+    (progn
+      (enkan-simple-3pane-remove-cheat-sheet-advice)
+      (message "enkan-simple-3pane-mode disabled."))))
 
-;;; Layout Management
+;;; ========================================
+;;; Main Setup Functions
+;;; ========================================
 
 (defun enkan-simple-3pane-setup ()
   "Setup 3-pane window layout for elisp development."
   (interactive)
-  ;; 3-pane-mode on
+  ;; Enable the minor mode
   (enkan-simple-3pane-mode 1)
-  
-  ;; set up the window layout
+
+  ;; Setup the window layout
   (enkan-simple-3pane-window-setup)
 
   ;; Setup display-buffer rules for misc window
   (enkan-simple-3pane-setup-display-buffer-rules)
 
-  ;; Enable the minor mode for keybindings
-  (unless enkan-simple-3pane-mode
-    (enkan-simple-3pane-mode 1))
-
   (message "3-pane layout initialized. Input file: %s"
     (file-name-nondirectory enkan-simple-3pane-input-file-path)))
 
-;;; Window Management
+(defun enkan-simple-3pane-reset ()
+  "Reset all 3-pane related variables and remove advices."
+  (interactive)
+  ;; Clear variables
+  (setq enkan-simple-3pane-input-buffer nil
+    enkan-simple-3pane-input-file-path nil
+    enkan-simple-3pane-input-left-up-window nil
+    enkan-simple-3pane-misc-left-down-window nil
+    enkan-simple-3pane-eat-right-full-window nil
+    enkan-simple-3pane-misc-buffer-history nil)
+
+  ;; Remove all advices
+  (advice-remove 'display-buffer #'enkan-simple-3pane-display-buffer-advice)
+  (advice-remove 'delete-window #'enkan-simple-3pane-protect-window-advice)
+  (advice-remove 'quit-window #'enkan-simple-3pane-quit-window-advice)
+
+  ;; Disable the mode
+  (enkan-simple-3pane-mode -1)
+
+  (message "3-pane layout reset."))
+
+;;; ========================================
+;;; Window Layout Functions
+;;; ========================================
 
 (defun enkan-simple-3pane-window-setup ()
-  "Set up fundamental 3-pane window layout"
+  "Set up fundamental 3-pane window layout."
   ;; Determine input file path from current directory
   (setq enkan-simple-3pane-input-file-path
     (enkan-repl--get-project-file-path default-directory))
-  ;; Open or create the input file and set as input buffer
+
+  ;; Open or create the input file
   (let ((input-file enkan-simple-3pane-input-file-path))
-    ;; Create file if it doesn't exist
     (unless (file-exists-p input-file)
       (enkan-repl--create-project-input-file default-directory))
-    ;; Open the file
     (setq enkan-simple-3pane-input-buffer (find-file-noselect input-file)))
 
   ;; Delete other windows to start fresh
@@ -144,27 +192,27 @@ Negative value makes text smaller."
 
   ;; Switch to input buffer in current window
   (switch-to-buffer enkan-simple-3pane-input-buffer)
-
-  ;; Setup left window (input)
   (setq enkan-simple-3pane-input-left-up-window (selected-window))
 
-  ;; Create right pane
+  ;; Create right pane (eat window)
   (let ((right-width (floor (* (window-width)
                               (- 1 enkan-simple-3pane-input-width-ratio)))))
     (split-window-horizontally (- right-width)))
 
-  ;; Still in left-up window, split vertically
-  ;; Create bottom window for misc
+  ;; Still in left-up window, split vertically to create misc window
   (let ((top-height (floor (* (window-height)
                              enkan-simple-3pane-input-height-ratio))))
-    (setq enkan-simple-3pane-misc-left-down-window (split-window-vertically top-height)))
+    (setq enkan-simple-3pane-misc-left-down-window
+      (split-window-vertically top-height)))
+
   ;; Setup eat buffer in right window
   (other-window 2)
   (setq enkan-simple-3pane-eat-right-full-window (selected-window))
 
-  ;; Get or create enkan-repl buffer for current file's directory
-  (let* ((input-dir (file-name-directory (or (buffer-file-name enkan-simple-3pane-input-buffer)
-                                           default-directory)))
+  ;; Get or create enkan-repl buffer
+  (let* ((input-dir (file-name-directory
+                      (or (buffer-file-name enkan-simple-3pane-input-buffer)
+                        default-directory)))
           (enkan-buffer-name (concat "*enkan:" input-dir "*"))
           (existing-buffer (get-buffer enkan-buffer-name)))
     (if (and existing-buffer (buffer-live-p existing-buffer))
@@ -172,17 +220,21 @@ Negative value makes text smaller."
       ;; Use enkan-repl-start-eat to create new session
       (let ((default-directory input-dir))
         (enkan-repl-start-eat))))
-  ;; Adjust text scale in eat buffer only
-  ;; Ensure this is buffer-local
+
+  ;; Adjust text scale in eat buffer
   (with-current-buffer (current-buffer)
     (setq-local face-remapping-alist nil)
     (face-remap-add-relative 'default :height enkan-simple-3pane-eat-text-scale))
+
   ;; Return to input window
   (select-window enkan-simple-3pane-input-left-up-window)
-  ;; Lock input and eat windows
+
+  ;; Lock windows
   (enkan-simple-3pane-lock-windows))
 
-;;; Configuration Utilities
+;;; ========================================
+;;; Window Navigation Functions
+;;; ========================================
 
 (defun enkan-simple-3pane-other-window ()
   "Switch between input and misc windows only.
@@ -198,6 +250,10 @@ Avoids switching to eat window."
     (t
       (when (window-live-p enkan-simple-3pane-input-left-up-window)
         (select-window enkan-simple-3pane-input-left-up-window)))))
+
+;;; ========================================
+;;; Window Lock/Unlock Functions
+;;; ========================================
 
 (defun enkan-simple-3pane-lock-windows ()
   "Lock input and eat windows to prevent opening other files in them."
@@ -215,9 +271,10 @@ Avoids switching to eat window."
             (window-live-p enkan-simple-3pane-eat-right-full-window))
       (set-window-dedicated-p enkan-simple-3pane-eat-right-full-window t)
       (push "eat" locked-windows))
-    ;; Report what was locked
+    ;; Report
     (if locked-windows
-      (message "Locked windows: %s" (string-join (nreverse locked-windows) ", "))
+      (message "Locked windows: %s"
+        (string-join (nreverse locked-windows) ", "))
       (message "No windows to lock."))))
 
 (defun enkan-simple-3pane-unlock-windows ()
@@ -236,64 +293,58 @@ Avoids switching to eat window."
             (window-live-p enkan-simple-3pane-eat-right-full-window))
       (set-window-dedicated-p enkan-simple-3pane-eat-right-full-window nil)
       (push "eat" unlocked-windows))
-    ;; Report what was unlocked
+    ;; Report
     (if unlocked-windows
-      (message "Unlocked windows: %s" (string-join (nreverse unlocked-windows) ", "))
+      (message "Unlocked windows: %s"
+        (string-join (nreverse unlocked-windows) ", "))
       (message "No windows to unlock."))))
 
-;;; Remote eat Control
+;;; ========================================
+;;; Remote eat Control Functions
+;;; ========================================
 
 (defun enkan-simple-3pane-send-escape ()
   "Send ESC to eat buffer from any window."
   (interactive)
-  (if (and enkan-simple-3pane-eat-right-full-window
-        (window-live-p enkan-simple-3pane-eat-right-full-window))
-    (save-window-excursion
-      (select-window enkan-simple-3pane-eat-right-full-window)
-      (enkan-repl-send-escape)
-      (message "Sent ESC to eat buffer"))
-    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
+  (enkan-simple-3pane--send-to-eat
+    'enkan-repl-send-escape "ESC"))
 
 (defun enkan-simple-3pane-send-1 ()
   "Send choice 1 to eat buffer from any window."
   (interactive)
-  (if (and enkan-simple-3pane-eat-right-full-window
-        (window-live-p enkan-simple-3pane-eat-right-full-window))
-    (save-window-excursion
-      (select-window enkan-simple-3pane-eat-right-full-window)
-      (enkan-repl-send-1)
-      (message "Sent 1 to eat buffer"))
-    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
+  (enkan-simple-3pane--send-to-eat
+    'enkan-repl-send-1 "1"))
 
 (defun enkan-simple-3pane-send-2 ()
   "Send choice 2 to eat buffer from any window."
   (interactive)
-  (if (and enkan-simple-3pane-eat-right-full-window
-        (window-live-p enkan-simple-3pane-eat-right-full-window))
-    (save-window-excursion
-      (select-window enkan-simple-3pane-eat-right-full-window)
-      (enkan-repl-send-2)
-      (message "Sent 2 to eat buffer"))
-    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
+  (enkan-simple-3pane--send-to-eat
+    'enkan-repl-send-2 "2"))
 
 (defun enkan-simple-3pane-send-3 ()
   "Send choice 3 to eat buffer from any window."
   (interactive)
+  (enkan-simple-3pane--send-to-eat
+    'enkan-repl-send-3 "3"))
+
+(defun enkan-simple-3pane--send-to-eat (func msg)
+  "Helper function to send commands to eat buffer.
+FUNC is the function to call, MSG is the message to display."
   (if (and enkan-simple-3pane-eat-right-full-window
         (window-live-p enkan-simple-3pane-eat-right-full-window))
     (save-window-excursion
       (select-window enkan-simple-3pane-eat-right-full-window)
-      (enkan-repl-send-3)
-      (message "Sent 3 to eat buffer"))
+      (funcall func)
+      (message "Sent %s to eat buffer" msg))
     (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
 
-;;; Helper Functions
+;;; ========================================
+;;; Display Buffer Management
+;;; ========================================
 
 (defun enkan-simple-3pane-setup-display-buffer-rules ()
   "Setup display-buffer rules to force misc buffers to left-down window."
-  ;; Override the default display-buffer function
   (advice-add 'display-buffer :around #'enkan-simple-3pane-display-buffer-advice)
-  ;; Prevent deletion of misc window
   (advice-add 'delete-window :around #'enkan-simple-3pane-protect-window-advice)
   (advice-add 'quit-window :around #'enkan-simple-3pane-quit-window-advice))
 
@@ -313,27 +364,32 @@ Avoids switching to eat window."
          ;; But not if we're in the input window editing a file
          (not (and (eq (selected-window) enkan-simple-3pane-input-left-up-window)
                 (buffer-file-name buffer))))
-        ;; Track buffer history for misc window (exclude temporary buffers)
-        (let ((current-buffer (window-buffer enkan-simple-3pane-misc-left-down-window)))
-          (when (and current-buffer
-                  (not (eq current-buffer buffer))
-                  ;; Only track non-temporary buffers
-                  (not (string-match-p "^\\*magit" (buffer-name current-buffer)))
-                  (not (string-match-p "^COMMIT_EDITMSG" (buffer-name current-buffer)))
-                  ;; Track file buffers and other persistent buffers
-                  (or (buffer-file-name current-buffer)
-                    (string-match-p "^\\*scratch\\*$" (buffer-name current-buffer))
-                    (string-match-p "^\\*Messages\\*$" (buffer-name current-buffer))))
-            (push current-buffer enkan-simple-3pane-misc-buffer-history)
-            ;; Keep history limited to avoid memory issues
-            (when (> (length enkan-simple-3pane-misc-buffer-history) 10)
-              (setq enkan-simple-3pane-misc-buffer-history
-                (butlast enkan-simple-3pane-misc-buffer-history)))))
+        ;; Track buffer history for misc window
+        (enkan-simple-3pane--track-buffer-history buffer)
         (set-window-buffer enkan-simple-3pane-misc-left-down-window buffer)
         (select-window enkan-simple-3pane-misc-left-down-window)
         enkan-simple-3pane-misc-left-down-window)
       ;; Default behavior
       (t (apply orig-fun buffer args)))))
+
+(defun enkan-simple-3pane--track-buffer-history (new-buffer)
+  "Track buffer history for the misc window.
+NEW-BUFFER is the buffer about to be displayed."
+  (let ((current-buffer (window-buffer enkan-simple-3pane-misc-left-down-window)))
+    (when (and current-buffer
+            (not (eq current-buffer new-buffer))
+            ;; Only track non-temporary buffers
+            (not (string-match-p "^\\*magit" (buffer-name current-buffer)))
+            (not (string-match-p "^COMMIT_EDITMSG" (buffer-name current-buffer)))
+            ;; Track file buffers and persistent buffers
+            (or (buffer-file-name current-buffer)
+              (string-match-p "^\\*scratch\\*$" (buffer-name current-buffer))
+              (string-match-p "^\\*Messages\\*$" (buffer-name current-buffer))))
+      (push current-buffer enkan-simple-3pane-misc-buffer-history)
+      ;; Keep history limited
+      (when (> (length enkan-simple-3pane-misc-buffer-history) 10)
+        (setq enkan-simple-3pane-misc-buffer-history
+          (butlast enkan-simple-3pane-misc-buffer-history))))))
 
 (defun enkan-simple-3pane-protect-window-advice (orig-fun &optional window)
   "Prevent deletion of protected windows in 3-pane layout."
@@ -343,7 +399,7 @@ Avoids switching to eat window."
       ((or (eq win enkan-simple-3pane-input-left-up-window)
          (eq win enkan-simple-3pane-misc-left-down-window)
          (eq win enkan-simple-3pane-eat-right-full-window))
-        ;; Just switch to scratch buffer instead of deleting window
+        ;; Switch to scratch buffer instead of deleting window
         (with-selected-window win
           (switch-to-buffer (get-buffer-create "*scratch*")))
         nil)
@@ -362,47 +418,27 @@ Avoids switching to eat window."
           (if (and (eq win enkan-simple-3pane-misc-left-down-window)
                 enkan-simple-3pane-misc-buffer-history)
             ;; For misc window, use buffer history
-            (let ((prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
-              (while (and prev-buffer
-                       (not (buffer-live-p prev-buffer))
-                       enkan-simple-3pane-misc-buffer-history)
-                (setq prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
-              (if (and prev-buffer (buffer-live-p prev-buffer))
-                (switch-to-buffer prev-buffer)
-                (switch-to-buffer (other-buffer))))
+            (enkan-simple-3pane--restore-previous-buffer)
             ;; For other windows, use standard other-buffer
             (switch-to-buffer (other-buffer))))
         nil)
       ;; For other windows, use original behavior
       (apply orig-fun kill window nil))))
 
-(defun enkan-simple-3pane-reset ()
-  "Reset all 3-pane related variables."
-  (interactive)
-  (setq enkan-simple-3pane-input-buffer nil
-    enkan-simple-3pane-input-left-up-window nil
-    enkan-simple-3pane-misc-left-down-window nil
-    enkan-simple-3pane-eat-right-full-window nil
-    enkan-simple-3pane-misc-buffer-history nil)
-  ;; Remove all advices
-  (advice-remove 'display-buffer #'enkan-simple-3pane-display-buffer-advice)
-  (advice-remove 'delete-window #'enkan-simple-3pane-protect-window-advice)
-  (advice-remove 'quit-window #'enkan-simple-3pane-quit-window-advice)
-  (message "3-pane layout reset."))
+(defun enkan-simple-3pane--restore-previous-buffer ()
+  "Restore the previous buffer from history in the misc window."
+  (let ((prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
+    (while (and prev-buffer
+             (not (buffer-live-p prev-buffer))
+             enkan-simple-3pane-misc-buffer-history)
+      (setq prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
+    (if (and prev-buffer (buffer-live-p prev-buffer))
+      (switch-to-buffer prev-buffer)
+      (switch-to-buffer (other-buffer)))))
 
-;;; Keybindings (optional - users can customize)
-
-(setq enkan-simple-3pane-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
-    (define-key map (kbd "M-t") 'other-window-or-split)
-    (define-key map (kbd "Esc") 'enkan-simple-3pane-send-escape)
-    (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
-    (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
-    (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
-    map))
-
-;;; Cheat Sheet Extension
+;;; ========================================
+;;; Cheat Sheet Integration
+;;; ========================================
 
 (defun enkan-simple-3pane-cheat-sheet-advice (orig-fun)
   "Advice to add 3-pane commands to enkan-repl cheat sheet."
@@ -410,42 +446,41 @@ Avoids switching to eat window."
     ;; When 3pane mode is active, show combined cheat sheet
     (progn
       (unless (featurep 'enkan-repl-constants)
-        (require 'enkan-repl-constants))
-      (let* ((original-candidates (if (boundp 'enkan-repl-cheat-sheet-candidates)
-                                    enkan-repl-cheat-sheet-candidates
-                                    '()))
+        (require 'enkan-repl-constants nil t))
+      (let* ((original-candidates
+               (if (boundp 'enkan-repl-cheat-sheet-candidates)
+                 enkan-repl-cheat-sheet-candidates
+                 '()))
               ;; Combine original and 3pane candidates
               (candidates (append original-candidates
                             enkan-simple-3pane-cheat-sheet-candidates)))
         (let ((completion-extra-properties
                 `(:annotation-function
                    (lambda (candidate)
-                     (let ((description (alist-get candidate ',candidates nil nil #'string=)))
+                     (let ((description (alist-get candidate ',candidates
+                                          nil nil #'string=)))
                        (when description
                          (format " — %s" description)))))))
-          (let ((selected-command (completing-read "enkan-repl & 3pane commands: " candidates)))
+          (let ((selected-command
+                  (completing-read "enkan-repl & 3pane commands: " candidates)))
             (when selected-command
               (call-interactively (intern selected-command)))))))
     ;; When 3pane mode is not active, use original function
     (funcall orig-fun)))
 
-;; Add advice when 3pane mode is enabled
 (defun enkan-simple-3pane-setup-cheat-sheet-advice ()
   "Setup advice for cheat sheet integration."
-  (advice-add 'enkan-repl-cheat-sheet :around #'enkan-simple-3pane-cheat-sheet-advice))
+  (advice-add 'enkan-repl-cheat-sheet :around
+    #'enkan-simple-3pane-cheat-sheet-advice))
 
 (defun enkan-simple-3pane-remove-cheat-sheet-advice ()
   "Remove advice for cheat sheet integration."
-  (advice-remove 'enkan-repl-cheat-sheet #'enkan-simple-3pane-cheat-sheet-advice))
+  (advice-remove 'enkan-repl-cheat-sheet
+    #'enkan-simple-3pane-cheat-sheet-advice))
 
-;; Automatically add advice when mode is enabled
-(add-hook 'enkan-simple-3pane-mode-hook
-  (lambda ()
-    (if enkan-simple-3pane-mode
-      (enkan-simple-3pane-setup-cheat-sheet-advice)
-      (enkan-simple-3pane-remove-cheat-sheet-advice))))
-
+;;; ========================================
 ;;; Provide
+;;; ========================================
 
 (provide 'simple-3-pane-window-layout)
 

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -68,7 +68,7 @@ Negative value makes text smaller."
   :type 'float
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-misc-height-ratio 0.55
+(defcustom enkan-3pane-input-height-ratio 0.55
   "Height ratio for misc window in left pane (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
@@ -95,7 +95,7 @@ Negative value makes text smaller."
   (setq enkan-3pane-misc-left-down-window (selected-window))
   ;; Create bottom window for eat
   (let ((eat-height (floor (* (window-height)
-                             (- 1 enkan-3pane-misc-height-ratio)))))
+                             (- 1 enkan-3pane-input-height-ratio)))))
     (split-window-vertically (- eat-height)))
   ;; Setup eat buffer in right window
   (other-window 2)
@@ -114,7 +114,9 @@ Negative value makes text smaller."
   (select-window enkan-3pane-input-left-up-window)
   ;; Lock input buffer
   (enkan-3pane-lock-input-buffer)
-  (message "3-pane layout initialized. Use C-c 3 o to switch windows."))
+  ;; Enable the minor mode for keybindings
+  (enkan-3pane-mode 1)
+  (message "3-pane layout initialized. Use M-t to switch windows."))
 
 (defun enkan-3pane-other-window ()
   "Switch between input and misc windows only.

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -169,9 +169,9 @@ Negative value makes text smaller."
           (existing-buffer (get-buffer enkan-buffer-name)))
     (if (and existing-buffer (buffer-live-p existing-buffer))
       (switch-to-buffer existing-buffer)
-      ;; Create new eat session with appropriate name
-      (eat)
-      (rename-buffer enkan-buffer-name t)))
+      ;; Use enkan-repl-start-eat to create new session
+      (let ((default-directory input-dir))
+        (enkan-repl-start-eat))))
   ;; Adjust text scale in eat buffer only
   ;; Ensure this is buffer-local
   (with-current-buffer (current-buffer)

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -43,9 +43,9 @@
 (require 'enkan-repl)
 
 ;; Load keybinding definitions and base keymap
-(let ((constants-file (expand-file-name "keybinding-constants.el" 
+(let ((constants-file (expand-file-name "keybinding-constants.el"
                                          (file-name-directory load-file-name)))
-      (keybinding-file (expand-file-name "keybinding.el" 
+      (keybinding-file (expand-file-name "keybinding.el"
                                           (file-name-directory load-file-name))))
   (when (file-exists-p constants-file)
     (load constants-file))

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -57,19 +57,19 @@
 (defvar enkan-3pane-eat-right-full-window nil
   "Window for eat terminal.")
 
-(defcustom enkan-3pane-eat-text-scale -0.5
+(defcustom enkan-3pane-eat-text-scale 0.85
   "Text scale adjustment for eat buffer.
 Negative value makes text smaller."
   :type 'integer
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-input-width-ratio 0.8
+(defcustom enkan-3pane-input-width-ratio 0.6
   "Width ratio for input window (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
 
-(defcustom enkan-3pane-misc-height-ratio 0.8
-  "Height ratio for misc window in right pane (0.0 to 1.0)."
+(defcustom enkan-3pane-misc-height-ratio 0.55
+  "Height ratio for misc window in left pane (0.0 to 1.0)."
   :type 'float
   :group 'enkan-repl)
 
@@ -105,10 +105,11 @@ Negative value makes text smaller."
   (if (get-buffer "*eat*")
     (switch-to-buffer "*eat*")
     (eat))
-  ;; Adjust text scale in eat buffer
-  ;; Clear all existing face remappings first
-  (setq-local face-remapping-alist nil)
-  (face-remap-add-relative 'default :height enkan-3pane-eat-text-scale)
+  ;; Adjust text scale in eat buffer only
+  ;; Ensure this is buffer-local
+  (with-current-buffer (current-buffer)
+    (setq-local face-remapping-alist nil)
+    (face-remap-add-relative 'default :height enkan-3pane-eat-text-scale))
   ;; Return to input window
   (select-window enkan-3pane-input-left-up-window)
   ;; Lock input buffer

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -100,10 +100,16 @@ Negative value makes text smaller."
   (other-window 2)
   (setq enkan-3pane-eat-right-full-window (selected-window))
 
-  ;; Start or switch to eat session
-  (if (get-buffer "*eat*")
-    (switch-to-buffer "*eat*")
-    (eat))
+  ;; Get or create enkan-repl buffer for current file's directory
+  (let* ((input-dir (file-name-directory (or (buffer-file-name enkan-3pane-input-buffer)
+                                              default-directory)))
+         (enkan-buffer-name (concat "*enkan:" input-dir "*"))
+         (existing-buffer (get-buffer enkan-buffer-name)))
+    (if (and existing-buffer (buffer-live-p existing-buffer))
+        (switch-to-buffer existing-buffer)
+      ;; Create new eat session with appropriate name
+      (eat)
+      (rename-buffer enkan-buffer-name t)))
   ;; Adjust text scale in eat buffer only
   ;; Ensure this is buffer-local
   (with-current-buffer (current-buffer)

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -313,10 +313,22 @@ Avoids switching to eat window."
          ;; But not if we're in the input window editing a file
          (not (and (eq (selected-window) enkan-simple-3pane-input-left-up-window)
                 (buffer-file-name buffer))))
-        ;; Track buffer history for misc window
+        ;; Track buffer history for misc window (exclude temporary buffers)
         (let ((current-buffer (window-buffer enkan-simple-3pane-misc-left-down-window)))
-          (unless (eq current-buffer buffer)
-            (push current-buffer enkan-simple-3pane-misc-buffer-history)))
+          (when (and current-buffer
+                  (not (eq current-buffer buffer))
+                  ;; Only track non-temporary buffers
+                  (not (string-match-p "^\\*magit" (buffer-name current-buffer)))
+                  (not (string-match-p "^COMMIT_EDITMSG" (buffer-name current-buffer)))
+                  ;; Track file buffers and other persistent buffers
+                  (or (buffer-file-name current-buffer)
+                    (string-match-p "^\\*scratch\\*$" (buffer-name current-buffer))
+                    (string-match-p "^\\*Messages\\*$" (buffer-name current-buffer))))
+            (push current-buffer enkan-simple-3pane-misc-buffer-history)
+            ;; Keep history limited to avoid memory issues
+            (when (> (length enkan-simple-3pane-misc-buffer-history) 10)
+              (setq enkan-simple-3pane-misc-buffer-history
+                (butlast enkan-simple-3pane-misc-buffer-history)))))
         (set-window-buffer enkan-simple-3pane-misc-left-down-window buffer)
         (select-window enkan-simple-3pane-misc-left-down-window)
         enkan-simple-3pane-misc-left-down-window)

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -99,11 +99,13 @@ Negative value makes text smaller."
   ;; set up the window layout
   (enkan-simple-3pane-window-setup)
 
+  ;; Setup display-buffer rules for misc window
+  (enkan-simple-3pane-setup-display-buffer-rules)
+
   ;; Enable the minor mode for keybindings
   (unless enkan-simple-3pane-mode
     (enkan-simple-3pane-mode 1))
-  ;; Setup display-buffer rules for misc window
-  (enkan-simple-3pane-setup-display-buffer-rules)
+
   (message "3-pane layout initialized. Input file: %s"
     (file-name-nondirectory enkan-simple-3pane-input-file-path)))
 
@@ -327,16 +329,14 @@ Avoids switching to eat window."
 
 (setq enkan-simple-3pane-mode-map
       (let ((map (make-sparse-keymap)))
-        (define-key map (kbd "C-c 3 s") 'enkan-simple-3pane-setup)
         (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
         (define-key map (kbd "M-t") 'other-window-or-split)
         (define-key map (kbd "C-c 3 l") 'enkan-simple-3pane-lock-input-buffer)
         (define-key map (kbd "C-c 3 u") 'enkan-simple-3pane-unlock-input-buffer)
-        (define-key map (kbd "C-c 3 e") 'enkan-simple-3pane-send-escape)
-        (define-key map (kbd "C-c 3 1") 'enkan-simple-3pane-send-1)
-        (define-key map (kbd "C-c 3 2") 'enkan-simple-3pane-send-2)
-        (define-key map (kbd "C-c 3 3") 'enkan-simple-3pane-send-3)
-        (define-key map (kbd "C-c 3 r") 'enkan-simple-3pane-reset)
+        (define-key map (kbd "Esc") 'enkan-simple-3pane-send-escape)
+        (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
+        (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
+        (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
         map))
 
 ;;; Provide

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -106,7 +106,9 @@ Negative value makes text smaller."
     (switch-to-buffer "*eat*")
     (eat))
   ;; Adjust text scale in eat buffer
-  (text-scale-adjust enkan-3pane-eat-text-scale)
+  ;; Clear all existing face remappings first
+  (setq-local face-remapping-alist nil)
+  (face-remap-add-relative 'default :height enkan-3pane-eat-text-scale)
   ;; Return to input window
   (select-window enkan-3pane-input-left-up-window)
   ;; Lock input buffer
@@ -224,7 +226,7 @@ Avoids switching to eat window."
 (defvar enkan-3pane-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c 3 s") 'enkan-3pane-setup)
-    (define-key map (kbd "C-c 3 o") 'enkan-3pane-other-window)
+    (define-key map (kbd "M-t") 'enkan-3pane-other-window)
     (define-key map (kbd "C-c 3 l") 'enkan-3pane-lock-input-buffer)
     (define-key map (kbd "C-c 3 u") 'enkan-3pane-unlock-input-buffer)
     (define-key map (kbd "C-c 3 e") 'enkan-3pane-send-escape)

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -45,6 +45,10 @@
 
 ;;; Variables
 
+(defvar enkan-simple-3pane-input-file-path nil
+  "Path to the input file determined from the current directory.
+This is set automatically when enkan-simple-3pane-setup is called.")
+
 (defvar enkan-simple-3pane-input-buffer nil
   "Buffer for input file (prompts).")
 
@@ -86,16 +90,29 @@ Negative value makes text smaller."
     (enkan-simple-3pane-mode 1))
   ;; Setup display-buffer rules for misc window
   (enkan-simple-3pane-setup-display-buffer-rules)
-  (message "3-pane layout initialized. Use C-t to switch windows."))
+  (message "3-pane layout initialized. Input file: %s"
+           (file-name-nondirectory enkan-simple-3pane-input-file-path)))
 
 ;;; Window Management
 
 (defun enkan-simple-3pane-window-setup ()
   "Set up fundamental 3-pane window layout"
-  ;; Save current buffer as input buffer
-  (setq enkan-simple-3pane-input-buffer (current-buffer))
+  ;; Determine input file path from current directory
+  (setq enkan-simple-3pane-input-file-path
+    (enkan-repl--get-project-file-path default-directory))
+  ;; Open or create the input file and set as input buffer
+  (let ((input-file enkan-simple-3pane-input-file-path))
+    ;; Create file if it doesn't exist
+    (unless (file-exists-p input-file)
+      (enkan-repl--create-project-input-file default-directory))
+    ;; Open the file
+    (setq enkan-simple-3pane-input-buffer (find-file-noselect input-file)))
+
   ;; Delete other windows to start fresh
   (delete-other-windows)
+
+  ;; Switch to input buffer in current window
+  (switch-to-buffer enkan-simple-3pane-input-buffer)
 
   ;; Setup left window (input)
   (setq enkan-simple-3pane-input-left-up-window (selected-window))

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -45,6 +45,15 @@
 
 ;;; Variables
 
+(defvar enkan-simple-3pane-cheat-sheet-candidates
+  '(("enkan-simple-3pane-setup" . "Setup 3-pane window layout")
+     ("enkan-simple-3pane-send-escape" . "Send ESC to eat buffer (Esc)")
+     ("enkan-simple-3pane-send-1" . "Send 1 to eat buffer (C-M-1)")
+     ("enkan-simple-3pane-send-2" . "Send 2 to eat buffer (C-M-2)")
+     ("enkan-simple-3pane-send-3" . "Send 3 to eat buffer (C-M-3)"))
+  "Additional commands for 3-pane layout to add to cheat sheet.
+Only important actions.")
+
 (defvar enkan-simple-3pane-input-file-path nil
   "Path to the input file determined from the current directory.
 This is set automatically when enkan-simple-3pane-setup is called.")
@@ -144,7 +153,7 @@ Negative value makes text smaller."
   ;; Still in left-up window, split vertically
   ;; Create bottom window for misc
   (let ((top-height (floor (* (window-height)
-                               enkan-simple-3pane-input-height-ratio))))
+                             enkan-simple-3pane-input-height-ratio))))
     (setq enkan-simple-3pane-misc-left-down-window (split-window-vertically top-height)))
   ;; Setup eat buffer in right window
   (other-window 2)
@@ -152,11 +161,11 @@ Negative value makes text smaller."
 
   ;; Get or create enkan-repl buffer for current file's directory
   (let* ((input-dir (file-name-directory (or (buffer-file-name enkan-simple-3pane-input-buffer)
-                                              default-directory)))
-         (enkan-buffer-name (concat "*enkan:" input-dir "*"))
-         (existing-buffer (get-buffer enkan-buffer-name)))
+                                           default-directory)))
+          (enkan-buffer-name (concat "*enkan:" input-dir "*"))
+          (existing-buffer (get-buffer enkan-buffer-name)))
     (if (and existing-buffer (buffer-live-p existing-buffer))
-        (switch-to-buffer existing-buffer)
+      (switch-to-buffer existing-buffer)
       ;; Create new eat session with appropriate name
       (eat)
       (rename-buffer enkan-buffer-name t)))
@@ -193,19 +202,19 @@ Avoids switching to eat window."
   (let ((locked-windows '()))
     ;; Lock input window
     (when (and enkan-simple-3pane-input-buffer
-               (buffer-live-p enkan-simple-3pane-input-buffer))
+            (buffer-live-p enkan-simple-3pane-input-buffer))
       (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
         (when window
           (set-window-dedicated-p window t)
           (push "input" locked-windows))))
     ;; Lock eat window
     (when (and enkan-simple-3pane-eat-right-full-window
-               (window-live-p enkan-simple-3pane-eat-right-full-window))
+            (window-live-p enkan-simple-3pane-eat-right-full-window))
       (set-window-dedicated-p enkan-simple-3pane-eat-right-full-window t)
       (push "eat" locked-windows))
     ;; Report what was locked
     (if locked-windows
-        (message "Locked windows: %s" (string-join (nreverse locked-windows) ", "))
+      (message "Locked windows: %s" (string-join (nreverse locked-windows) ", "))
       (message "No windows to lock."))))
 
 (defun enkan-simple-3pane-unlock-windows ()
@@ -214,19 +223,19 @@ Avoids switching to eat window."
   (let ((unlocked-windows '()))
     ;; Unlock input window
     (when (and enkan-simple-3pane-input-buffer
-               (buffer-live-p enkan-simple-3pane-input-buffer))
+            (buffer-live-p enkan-simple-3pane-input-buffer))
       (let ((window (get-buffer-window enkan-simple-3pane-input-buffer)))
         (when window
           (set-window-dedicated-p window nil)
           (push "input" unlocked-windows))))
     ;; Unlock eat window
     (when (and enkan-simple-3pane-eat-right-full-window
-               (window-live-p enkan-simple-3pane-eat-right-full-window))
+            (window-live-p enkan-simple-3pane-eat-right-full-window))
       (set-window-dedicated-p enkan-simple-3pane-eat-right-full-window nil)
       (push "eat" unlocked-windows))
     ;; Report what was unlocked
     (if unlocked-windows
-        (message "Unlocked windows: %s" (string-join (nreverse unlocked-windows) ", "))
+      (message "Unlocked windows: %s" (string-join (nreverse unlocked-windows) ", "))
       (message "No windows to unlock."))))
 
 ;;; Remote eat Control
@@ -289,66 +298,66 @@ Avoids switching to eat window."
   "Advice to redirect buffers to misc window when appropriate."
   (let ((buffer-name (buffer-name (get-buffer buffer))))
     (cond
-     ;; Don't redirect eat buffers
-     ((string-match-p "^\\*enkan:" buffer-name)
-      (apply orig-fun buffer args))
-     ;; Don't redirect buffers that are already displayed
-     ((get-buffer-window buffer)
-      (apply orig-fun buffer args))
-     ;; Redirect everything else to misc window if it exists
-     ((and enkan-simple-3pane-misc-left-down-window
-           (window-live-p enkan-simple-3pane-misc-left-down-window)
-           ;; But not if we're in the input window editing a file
-           (not (and (eq (selected-window) enkan-simple-3pane-input-left-up-window)
-                     (buffer-file-name buffer))))
-      ;; Track buffer history for misc window
-      (let ((current-buffer (window-buffer enkan-simple-3pane-misc-left-down-window)))
-        (unless (eq current-buffer buffer)
-          (push current-buffer enkan-simple-3pane-misc-buffer-history)))
-      (set-window-buffer enkan-simple-3pane-misc-left-down-window buffer)
-      (select-window enkan-simple-3pane-misc-left-down-window)
-      enkan-simple-3pane-misc-left-down-window)
-     ;; Default behavior
-     (t (apply orig-fun buffer args)))))
+      ;; Don't redirect eat buffers
+      ((string-match-p "^\\*enkan:" buffer-name)
+        (apply orig-fun buffer args))
+      ;; Don't redirect buffers that are already displayed
+      ((get-buffer-window buffer)
+        (apply orig-fun buffer args))
+      ;; Redirect everything else to misc window if it exists
+      ((and enkan-simple-3pane-misc-left-down-window
+         (window-live-p enkan-simple-3pane-misc-left-down-window)
+         ;; But not if we're in the input window editing a file
+         (not (and (eq (selected-window) enkan-simple-3pane-input-left-up-window)
+                (buffer-file-name buffer))))
+        ;; Track buffer history for misc window
+        (let ((current-buffer (window-buffer enkan-simple-3pane-misc-left-down-window)))
+          (unless (eq current-buffer buffer)
+            (push current-buffer enkan-simple-3pane-misc-buffer-history)))
+        (set-window-buffer enkan-simple-3pane-misc-left-down-window buffer)
+        (select-window enkan-simple-3pane-misc-left-down-window)
+        enkan-simple-3pane-misc-left-down-window)
+      ;; Default behavior
+      (t (apply orig-fun buffer args)))))
 
 (defun enkan-simple-3pane-protect-window-advice (orig-fun &optional window)
   "Prevent deletion of protected windows in 3-pane layout."
   (let ((win (or window (selected-window))))
     (cond
-     ;; Never allow deletion of our 3 main windows
-     ((or (eq win enkan-simple-3pane-input-left-up-window)
-          (eq win enkan-simple-3pane-misc-left-down-window)
-          (eq win enkan-simple-3pane-eat-right-full-window))
-      ;; Just switch to scratch buffer instead of deleting window
-      (with-selected-window win
-        (switch-to-buffer (get-buffer-create "*scratch*")))
-      nil)
-     ;; Allow deletion of other windows
-     (t (apply orig-fun window nil)))))
+      ;; Never allow deletion of our 3 main windows
+      ((or (eq win enkan-simple-3pane-input-left-up-window)
+         (eq win enkan-simple-3pane-misc-left-down-window)
+         (eq win enkan-simple-3pane-eat-right-full-window))
+        ;; Just switch to scratch buffer instead of deleting window
+        (with-selected-window win
+          (switch-to-buffer (get-buffer-create "*scratch*")))
+        nil)
+      ;; Allow deletion of other windows
+      (t (apply orig-fun window nil)))))
 
 (defun enkan-simple-3pane-quit-window-advice (orig-fun &optional kill window)
   "Prevent quit-window from deleting protected windows."
   (let ((win (or window (selected-window))))
     (if (or (eq win enkan-simple-3pane-input-left-up-window)
-            (eq win enkan-simple-3pane-misc-left-down-window)
-            (eq win enkan-simple-3pane-eat-right-full-window))
-        ;; For protected windows, switch to previous buffer
-        (progn
-          (with-selected-window win
-            (if (and (eq win enkan-simple-3pane-misc-left-down-window)
-                     enkan-simple-3pane-misc-buffer-history)
-                ;; For misc window, use buffer history
-                (let ((prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
-                  (while (and prev-buffer
-                              (not (buffer-live-p prev-buffer))
-                              enkan-simple-3pane-misc-buffer-history)
-                    (setq prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
-                  (if (and prev-buffer (buffer-live-p prev-buffer))
-                      (switch-to-buffer prev-buffer)
-                    (switch-to-buffer (other-buffer))))
-              ;; For other windows, use standard other-buffer
-              (switch-to-buffer (other-buffer))))
-          nil)
+          (eq win enkan-simple-3pane-misc-left-down-window)
+          (eq win enkan-simple-3pane-eat-right-full-window))
+      ;; For protected windows, switch to previous buffer
+      (progn
+        (with-selected-window win
+          (if (and (eq win enkan-simple-3pane-misc-left-down-window)
+                enkan-simple-3pane-misc-buffer-history)
+            ;; For misc window, use buffer history
+            (let ((prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
+              (while (and prev-buffer
+                       (not (buffer-live-p prev-buffer))
+                       enkan-simple-3pane-misc-buffer-history)
+                (setq prev-buffer (pop enkan-simple-3pane-misc-buffer-history)))
+              (if (and prev-buffer (buffer-live-p prev-buffer))
+                (switch-to-buffer prev-buffer)
+                (switch-to-buffer (other-buffer))))
+            ;; For other windows, use standard other-buffer
+            (switch-to-buffer (other-buffer))))
+        nil)
       ;; For other windows, use original behavior
       (apply orig-fun kill window nil))))
 
@@ -377,6 +386,49 @@ Avoids switching to eat window."
     (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
     (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
     map))
+
+;;; Cheat Sheet Extension
+
+(defun enkan-simple-3pane-cheat-sheet-advice (orig-fun)
+  "Advice to add 3-pane commands to enkan-repl cheat sheet."
+  (if enkan-simple-3pane-mode
+    ;; When 3pane mode is active, show combined cheat sheet
+    (progn
+      (unless (featurep 'enkan-repl-constants)
+        (require 'enkan-repl-constants))
+      (let* ((original-candidates (if (boundp 'enkan-repl-cheat-sheet-candidates)
+                                    enkan-repl-cheat-sheet-candidates
+                                    '()))
+              ;; Combine original and 3pane candidates
+              (candidates (append original-candidates
+                            enkan-simple-3pane-cheat-sheet-candidates)))
+        (let ((completion-extra-properties
+                `(:annotation-function
+                   (lambda (candidate)
+                     (let ((description (alist-get candidate ',candidates nil nil #'string=)))
+                       (when description
+                         (format " — %s" description)))))))
+          (let ((selected-command (completing-read "enkan-repl & 3pane commands: " candidates)))
+            (when selected-command
+              (call-interactively (intern selected-command)))))))
+    ;; When 3pane mode is not active, use original function
+    (funcall orig-fun)))
+
+;; Add advice when 3pane mode is enabled
+(defun enkan-simple-3pane-setup-cheat-sheet-advice ()
+  "Setup advice for cheat sheet integration."
+  (advice-add 'enkan-repl-cheat-sheet :around #'enkan-simple-3pane-cheat-sheet-advice))
+
+(defun enkan-simple-3pane-remove-cheat-sheet-advice ()
+  "Remove advice for cheat sheet integration."
+  (advice-remove 'enkan-repl-cheat-sheet #'enkan-simple-3pane-cheat-sheet-advice))
+
+;; Automatically add advice when mode is enabled
+(add-hook 'enkan-simple-3pane-mode-hook
+  (lambda ()
+    (if enkan-simple-3pane-mode
+      (enkan-simple-3pane-setup-cheat-sheet-advice)
+      (enkan-simple-3pane-remove-cheat-sheet-advice))))
 
 ;;; Provide
 

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -108,6 +108,9 @@ Negative value makes text smaller."
 (defun enkan-simple-3pane-setup ()
   "Setup 3-pane window layout for elisp development."
   (interactive)
+  ;; 3-pane-mode on
+  (enkan-simple-3pane-mode 1)
+  
   ;; set up the window layout
   (enkan-simple-3pane-window-setup)
 

--- a/scripts/generate-docs.el
+++ b/scripts/generate-docs.el
@@ -107,7 +107,7 @@
                   (setq result (concat result "- =enkan-repl-send-1/2/3= - Send numbered choices for AI prompts\n"))))
                ((string= func-name "enkan-repl-open-project-input-file")
                 (setq result (concat result "- =" func-name "= - Create/open persistent input file for current directory\n")))
-               ((string= func-name "enkan-repl-setup-window-layout")
+               ((string= func-name "enkan-repl-setup")
                 (setq result (concat result "- =" func-name "= - Arrange windows for (the author's) optimal workflow\n")))
                (t
                 (setq result (concat result "- =" func-name "= - " description "\n"))))))

--- a/test/generate-docs-test.el
+++ b/test/generate-docs-test.el
@@ -252,7 +252,7 @@ It spans multiple lines for testing.\"
 
             ;; Check function references
             (should (string-match-p "enkan-repl-start-eat" content))
-            (should (string-match-p "enkan-repl-setup-window-layout" content))
+            (should (string-match-p "enkan-repl-setup" content))
             (should (string-match-p "enkan-repl-send-region" content))
             (should (string-match-p "enkan-repl-status" content))))
 


### PR DESCRIPTION
## Summary
- Add centralized keybinding management system
- Add two window layout examples (3-pane and dual-task)
- Improve naming consistency across setup functions

## Changes
- **Keybinding Management**: Added `keybinding-constants.el` for centralized keybinding definitions
- **3-pane Layout**: Added `simple-3pane-window-layout.el` for elisp development with AI assistants
- **Dual-task Layout**: Added `dual-task-window-layout.el` for managing two enkan-repl sessions simultaneously
- **Function Rename**: `enkan-repl-setup-window-layout` → `enkan-repl-setup` for consistency

## Test Plan
- [ ] Load `examples/keybinding.el` and verify base keybindings work
- [ ] Test 3-pane layout with `M-x enkan-simple-3pane-setup`
- [ ] Test dual-task layout with `M-x enkan-dual-task-setup`
- [ ] Verify renamed `enkan-repl-setup` function works

🤖 Generated with [Claude Code](https://claude.ai/code)