### PR TITLE
feat: Add custom window navigation command

### DIFF
--- a/examples/commands.el
+++ b/examples/commands.el
@@ -1,0 +1,28 @@
+;;; commands.el --- Custom commands for personal use -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; Keywords: convenience, tools
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Commentary:
+
+;; Custom commands for personal use.
+
+;;; Code:
+
+(defun other-window-or-split ()
+  "split it horizontally and move
+if the window is not split."
+  (interactive)
+  (cond ((one-window-p)
+          (split-window-horizontally)
+          (other-window 1))
+    (t
+      (other-window 1))))
+
+(provide 'commands)
+
+;;; commands.el ends here

--- a/examples/commands.el
+++ b/examples/commands.el
@@ -17,9 +17,10 @@
   "split it horizontally and move
 if the window is not split."
   (interactive)
-  (cond ((one-window-p)
-          (split-window-horizontally)
-          (other-window 1))
+  (cond
+    ((one-window-p)
+      (split-window-horizontally)
+      (other-window 1))
     (t
       (other-window 1))))
 

--- a/examples/keybinding-constants.el
+++ b/examples/keybinding-constants.el
@@ -28,8 +28,8 @@
 
 (defconst enkan-keybinding-definitions
   '(;; Window Navigation
-     ("C-t" other-window "Other window" window-navigation)
-     ("M-t" other-window "Other window" window-navigation)
+     ("C-t" other-window-or-split "Other window" window-navigation)
+     ("M-t" other-window-or-split "Other window" window-navigation)
      ("C-M-l" enkan-repl-setup "Setup window layout" window-navigation)
 
      ;; Text Sending


### PR DESCRIPTION
## Summary
- Add `other-window-or-split` command for intelligent window navigation
- Update keybinding definitions to use the new command

## Test plan
- [ ] Load the new `examples/commands.el` file
- [ ] Test the `other-window-or-split` function with single window (should split)
- [ ] Test the function with multiple windows (should cycle through)
- [ ] Verify keybindings work correctly with `C-t` and `M-t`

🤖 Generated with [Claude Code](https://claude.ai/code)