### PR TITLE
Add macOS notification support for Claude Code task completion

### DIFF
--- a/enkan-repl-mac-notify.el
+++ b/enkan-repl-mac-notify.el
@@ -72,8 +72,8 @@ Defaults to a system sound. Change this to your preferred sound."
   "Build osascript command for notification with MESSAGE and TITLE.
 This is a pure function for testing."
   (format "display notification \"%s\" with title \"%s\""
-          (replace-regexp-in-string "\"" "\\\\\"" message t t)
-          (replace-regexp-in-string "\"" "\\\\\"" title t t)))
+          (replace-regexp-in-string "\"" "\\\"" message t t)
+          (replace-regexp-in-string "\"" "\\\"" title t t)))
 
 (defun enkan-repl--should-play-sound-p (sys-type enabled-p file-path)
   "Check if sound should be played based on SYS-TYPE, ENABLED-P, and FILE-PATH.

--- a/enkan-repl-mac-notify.el
+++ b/enkan-repl-mac-notify.el
@@ -1,0 +1,146 @@
+;;; enkan-repl-mac-notify.el --- macOS specific notifications for enkan-repl -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; Version: 0.9.0
+;; Package-Requires: ((emacs "28.1"))
+;; Keywords: enkan ai tools convenience macos notification sound
+;; URL: https://github.com/phasetr/enkan-repl
+;; License: MIT
+
+;; This file is not part of GNU Emacs.
+
+;; Permission is hereby granted, free of charge, to any person obtaining a copy
+;; of this software and associated documentation files (the "Software"), to deal
+;; in the Software without restriction, including without limitation the rights
+;; to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+;; copies of the Software, and to permit persons to whom the Software is
+;; furnished to do so, subject to the following conditions:
+
+;; The above copyright notice and this permission notice shall be included in all
+;; copies or substantial portions of the Software.
+
+;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+;; IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+;; FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+;; AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+;; LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+;; OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; SOFTWARE.
+
+;;; Commentary:
+
+;; Provides macOS specific sound and visual notifications for enkan-repl.
+;; This module allows enkan-repl to play sounds and show native macOS notifications
+;; when tasks complete or when awaiting user input.
+
+;;; Code:
+
+(defgroup enkan-repl-notifications nil
+  "Customization options for enkan-repl notifications."
+  :group 'enkan-repl)
+
+(defcustom enkan-repl-notify-sound-on-completion t
+  "Enable or disable playing a sound on task completion."
+  :type 'boolean
+  :group 'enkan-repl-notifications)
+
+(defcustom enkan-repl-notify-sound-file
+  "/System/Library/Sounds/Glass.aiff"
+  "Path to the sound file to play on task completion.
+Defaults to a system sound. Change this to your preferred sound."
+  :type 'file
+  :group 'enkan-repl-notifications)
+
+(defcustom enkan-repl-notify-macos-notification-on-completion t
+  "Enable or disable macOS native notification on task completion."
+  :type 'boolean
+  :group 'enkan-repl-notifications)
+
+(defcustom enkan-repl-notify-macos-notification-title "Enkan REPL"
+  "Title for the macOS native notification."
+  :type 'string
+  :group 'enkan-repl-notifications)
+
+(defcustom enkan-repl-notify-macos-notification-message "Task completed!"
+  "Default message for the macOS native notification."
+  :type 'string
+  :group 'enkan-repl-notifications)
+
+(defun enkan-repl--build-notification-command (message title)
+  "Build osascript command for notification with MESSAGE and TITLE.
+This is a pure function for testing."
+  (format "display notification \"%s\" with title \"%s\""
+          (replace-regexp-in-string "\"" "\\\\\"" message t t)
+          (replace-regexp-in-string "\"" "\\\\\"" title t t)))
+
+(defun enkan-repl--should-play-sound-p (sys-type enabled-p file-path)
+  "Check if sound should be played based on SYS-TYPE, ENABLED-P, and FILE-PATH.
+This is a pure function for testing."
+  (and (eq sys-type 'darwin)
+       enabled-p
+       (stringp file-path)
+       (not (string-empty-p file-path))))
+
+(defun enkan-repl--should-show-notification-p (sys-type enabled-p)
+  "Check if notification should be shown based on SYS-TYPE and ENABLED-P.
+This is a pure function for testing."
+  (and (eq sys-type 'darwin)
+       enabled-p))
+
+(defun enkan-repl--play-completion-sound ()
+  "Play a notification sound on macOS using afplay.
+This function is intended for internal use by enkan-repl."
+  (when (enkan-repl--should-play-sound-p
+         system-type
+         enkan-repl-notify-sound-on-completion
+         enkan-repl-notify-sound-file)
+    (when (file-exists-p enkan-repl-notify-sound-file)
+      (start-process "enkan-repl-sound" nil "afplay" enkan-repl-notify-sound-file))))
+
+(defun enkan-repl--show-completion-notification (&optional message)
+  "Show a macOS native notification on task completion using osascript.
+MESSAGE is an optional string to override the default notification message.
+This function is intended for internal use by enkan-repl."
+  (when (enkan-repl--should-show-notification-p
+         system-type
+         enkan-repl-notify-macos-notification-on-completion)
+    (let* ((notification-message (or message enkan-repl-notify-macos-notification-message))
+           (osascript-command (enkan-repl--build-notification-command
+                              notification-message
+                              enkan-repl-notify-macos-notification-title)))
+      (start-process "enkan-repl-notification" nil "osascript" "-e" osascript-command))))
+
+(defun enkan-repl-notify-task-complete (&optional message)
+  "Notify user that a task has completed.
+Optional MESSAGE can override the default notification message.
+This is a public function that can be called by other enkan-repl modules."
+  (interactive)
+  (enkan-repl--play-completion-sound)
+  (enkan-repl--show-completion-notification message))
+
+(defun enkan-repl--bell-handler ()
+  "Handle bell events from Claude Code.
+This function is called when Claude Code sends a bell character."
+  (when enkan-repl-notify-macos-notification-on-completion
+    (enkan-repl-notify-task-complete "Claude Code task completed!")))
+
+(defun enkan-repl-setup-bell-handler ()
+  "Set up or re-setup the completion notification handler.
+Use this if system notifications aren't working after starting a session."
+  (interactive)
+  ;; Find eat buffer matching pattern *enkan:*
+  (let ((eat-buffer (seq-find (lambda (buf)
+                                (string-match-p "^\\*enkan:.*\\*$" (buffer-name buf)))
+                              (buffer-list))))
+    (when eat-buffer
+      (with-current-buffer eat-buffer
+        ;; Set buffer-local ring-bell-function to handle bells
+        (setq-local ring-bell-function #'enkan-repl--bell-handler)
+        (setq-local visible-bell nil)
+        (message "Bell handler configured for enkan-repl session in buffer: %s" (buffer-name))))))
+
+(provide 'enkan-repl-mac-notify)
+
+;;; enkan-repl-mac-notify.el ends here

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -57,6 +57,10 @@
 (when (locate-library "enkan-repl-utils")
   (require 'enkan-repl-utils))
 
+;; Load macOS specific notifications if on macOS
+(when (and (eq system-type 'darwin) (locate-library "enkan-repl-mac-notify"))
+  (require 'enkan-repl-mac-notify))
+
 ;; Declare external functions to avoid byte-compile warnings
 (declare-function enkan-repl-utils--extract-function-info "enkan-repl-utils" (file-path))
 (declare-function enkan-repl--find-session-buffer-pure "enkan-repl-utils" (selected-name buffer-info-list))
@@ -883,7 +887,11 @@ Category: Session Controller"
                 (rename-buffer new-buffer-name t)
               (error
                (message "Warning: Failed to rename eat buffer: %s" (error-message-string err))
-               nil)))
+               nil))
+            ;; Setup bell handler for Claude Code notifications
+            (when (and (eq system-type 'darwin)
+                       (fboundp 'enkan-repl-setup-bell-handler))
+              (run-at-time 0.5 nil #'enkan-repl-setup-bell-handler)))
           ;; Ensure buffer is displayed in target window
           (set-window-buffer target-window eat-buffer))
         ;; Return to original window (input file)

--- a/test/enkan-repl-mac-notify-test.el
+++ b/test/enkan-repl-mac-notify-test.el
@@ -24,15 +24,15 @@
   
   ;; Message with quotes that need escaping
   (should (equal (enkan-repl--build-notification-command "He said \"Hello\"" "Title")
-                 "display notification \"He said \\\\\"Hello\\\\\"\" with title \"Title\""))
+                 "display notification \"He said \\\"Hello\\\"\" with title \"Title\""))
   
   ;; Title with quotes that need escaping
   (should (equal (enkan-repl--build-notification-command "Message" "\"Important\" Title")
-                 "display notification \"Message\" with title \"\\\\\"Important\\\\\" Title\""))
+                 "display notification \"Message\" with title \"\\\"Important\\\" Title\""))
   
   ;; Both with quotes
   (should (equal (enkan-repl--build-notification-command "\"Quoted\" message" "\"Quoted\" title")
-                 "display notification \"\\\\\"Quoted\\\\\" message\" with title \"\\\\\"Quoted\\\\\" title\""))
+                 "display notification \"\\\"Quoted\\\" message\" with title \"\\\"Quoted\\\" title\""))
   
   ;; Empty strings
   (should (equal (enkan-repl--build-notification-command "" "")

--- a/test/enkan-repl-mac-notify-test.el
+++ b/test/enkan-repl-mac-notify-test.el
@@ -1,0 +1,104 @@
+;;; enkan-repl-mac-notify-test.el --- Tests for enkan-repl-mac-notify -*- lexical-binding: t -*-
+
+;; Copyright (C) 2025 phasetr
+
+;; Author: phasetr <phasetr@gmail.com>
+;; License: MIT
+
+;;; Commentary:
+
+;; Tests for macOS notification functionality in enkan-repl.
+
+;;; Code:
+
+(require 'ert)
+(require 'enkan-repl-mac-notify)
+
+;;;; Pure Function Tests
+
+(ert-deftest test-enkan-repl--build-notification-command ()
+  "Test notification command building."
+  ;; Basic message and title
+  (should (equal (enkan-repl--build-notification-command "Hello" "Title")
+                 "display notification \"Hello\" with title \"Title\""))
+  
+  ;; Message with quotes that need escaping
+  (should (equal (enkan-repl--build-notification-command "He said \"Hello\"" "Title")
+                 "display notification \"He said \\\\\"Hello\\\\\"\" with title \"Title\""))
+  
+  ;; Title with quotes that need escaping
+  (should (equal (enkan-repl--build-notification-command "Message" "\"Important\" Title")
+                 "display notification \"Message\" with title \"\\\\\"Important\\\\\" Title\""))
+  
+  ;; Both with quotes
+  (should (equal (enkan-repl--build-notification-command "\"Quoted\" message" "\"Quoted\" title")
+                 "display notification \"\\\\\"Quoted\\\\\" message\" with title \"\\\\\"Quoted\\\\\" title\""))
+  
+  ;; Empty strings
+  (should (equal (enkan-repl--build-notification-command "" "")
+                 "display notification \"\" with title \"\"")))
+
+(ert-deftest test-enkan-repl--should-play-sound-p ()
+  "Test sound playing conditions."
+  ;; macOS with sound enabled and valid file path
+  (should (enkan-repl--should-play-sound-p 'darwin t "/System/Library/Sounds/Glass.aiff"))
+  
+  ;; macOS with sound disabled
+  (should-not (enkan-repl--should-play-sound-p 'darwin nil "/System/Library/Sounds/Glass.aiff"))
+  
+  ;; Non-macOS system
+  (should-not (enkan-repl--should-play-sound-p 'gnu/linux t "/System/Library/Sounds/Glass.aiff"))
+  (should-not (enkan-repl--should-play-sound-p 'windows-nt t "/System/Library/Sounds/Glass.aiff"))
+  
+  ;; macOS with empty file path
+  (should-not (enkan-repl--should-play-sound-p 'darwin t ""))
+  
+  ;; macOS with nil file path
+  (should-not (enkan-repl--should-play-sound-p 'darwin t nil))
+  
+  ;; All conditions false
+  (should-not (enkan-repl--should-play-sound-p 'gnu/linux nil "")))
+
+(ert-deftest test-enkan-repl--should-show-notification-p ()
+  "Test notification display conditions."
+  ;; macOS with notifications enabled
+  (should (enkan-repl--should-show-notification-p 'darwin t))
+  
+  ;; macOS with notifications disabled
+  (should-not (enkan-repl--should-show-notification-p 'darwin nil))
+  
+  ;; Non-macOS systems
+  (should-not (enkan-repl--should-show-notification-p 'gnu/linux t))
+  (should-not (enkan-repl--should-show-notification-p 'windows-nt t))
+  
+  ;; Non-macOS with notifications disabled
+  (should-not (enkan-repl--should-show-notification-p 'gnu/linux nil)))
+
+;;;; Integration Tests (require manual verification)
+
+(ert-deftest test-enkan-repl-notify-task-complete-manual ()
+  "Manual test for notification functionality.
+This test requires manual verification that notification appears and sound plays."
+  :tags '(:manual)
+  (when (eq system-type 'darwin)
+    ;; Save original values
+    (let ((orig-sound enkan-repl-notify-sound-on-completion)
+          (orig-notification enkan-repl-notify-macos-notification-on-completion))
+      (unwind-protect
+          (progn
+            ;; Enable both sound and notification
+            (setq enkan-repl-notify-sound-on-completion t)
+            (setq enkan-repl-notify-macos-notification-on-completion t)
+            
+            ;; Call the function - should show notification and play sound
+            (enkan-repl-notify-task-complete "Test notification from ERT")
+            
+            ;; Manual verification required
+            (message "Check: Did you see a notification and hear a sound?"))
+        ;; Restore original values
+        (setq enkan-repl-notify-sound-on-completion orig-sound)
+        (setq enkan-repl-notify-macos-notification-on-completion orig-notification)))))
+
+(provide 'enkan-repl-mac-notify-test)
+
+;;; enkan-repl-mac-notify-test.el ends here


### PR DESCRIPTION
## Summary
- Add bell character detection to trigger notifications when Claude Code completes tasks
- Provide visual and audio feedback similar to VSCode's Claude integration
- Support customizable notification settings for macOS users

## Implementation Details
- New `enkan-repl-mac-notify.el` module for macOS-specific notification handling
- Detect bell character (`\007`) from Claude Code via eat terminal's `ring-bell-function`
- Pure functions for testability with comprehensive unit tests
- Automatic setup when starting eat sessions on macOS

## Test plan
- [x] Unit tests for pure functions pass
- [x] Manual verification of notifications on macOS
- [x] Sound plays when Claude Code tasks complete
- [x] Visual notifications appear in macOS notification center

🤖 Generated with [Claude Code](https://claude.ai/code)