### PR TITLE
feat: extend keybindings to 5 and remove 3pane-specific send functions

### DIFF
--- a/examples/keybinding-constants.el
+++ b/examples/keybinding-constants.el
@@ -40,6 +40,8 @@
      ("C-M-1" enkan-repl-send-1 "Send 1 to REPL" quick-actions)
      ("C-M-2" enkan-repl-send-2 "Send 2 to REPL" quick-actions)
      ("C-M-3" enkan-repl-send-3 "Send 3 to REPL" quick-actions)
+     ("C-M-4" enkan-repl-send-4 "Send 4 to REPL" quick-actions)
+     ("C-M-5" enkan-repl-send-5 "Send 5 to REPL" quick-actions)
      ("C-M-b" enkan-repl-recenter-bottom "Recenter at bottom" quick-actions)
 
      ;; Project Management
@@ -64,11 +66,7 @@ Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
 ;;; ========================================
 
 (defconst enkan-simple-3pane-keybinding-overrides
-  '(("C-M-t" enkan-simple-3pane-other-window "Switch between input/misc windows" window-navigation)
-     ("<escape>" enkan-simple-3pane-send-escape "Send ESC to eat buffer" quick-actions)
-     ("C-M-1" enkan-simple-3pane-send-1 "Send 1 to eat buffer" quick-actions)
-     ("C-M-2" enkan-simple-3pane-send-2 "Send 2 to eat buffer" quick-actions)
-     ("C-M-3" enkan-simple-3pane-send-3 "Send 3 to eat buffer" quick-actions))
+  '(("C-M-t" enkan-simple-3pane-other-window "Switch between input/misc windows" window-navigation))
   "Keybinding overrides for 3pane mode.
 Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
 
@@ -78,11 +76,7 @@ Each entry is (KEY COMMAND DESCRIPTION CATEGORY).")
     (enkan-simple-3pane-describe-keybindings "Show 3pane keybindings")
     (enkan-simple-3pane-other-window "Switch between input/misc windows")
     (enkan-simple-3pane-lock-windows "Lock input and eat windows")
-    (enkan-simple-3pane-unlock-windows "Unlock input and eat windows")
-    (enkan-simple-3pane-send-escape "Send ESC to eat buffer")
-    (enkan-simple-3pane-send-1 "Send 1 to eat buffer")
-    (enkan-simple-3pane-send-2 "Send 2 to eat buffer")
-    (enkan-simple-3pane-send-3 "Send 3 to eat buffer"))
+    (enkan-simple-3pane-unlock-windows "Unlock input and eat windows"))
   "Command definitions for 3pane mode cheat sheet.
 Each entry is (COMMAND DESCRIPTION).")
 

--- a/examples/simple-3pane-window-layout.el
+++ b/examples/simple-3pane-window-layout.el
@@ -129,11 +129,7 @@ This is set automatically when enkan-simple-3pane-setup is called.")
       ("enkan-simple-3pane-describe-keybindings" . "Show 3pane keybindings")
       ("enkan-simple-3pane-other-window" . "Switch between input/misc windows (C-t)")
       ("enkan-simple-3pane-lock-windows" . "Lock input and eat windows")
-      ("enkan-simple-3pane-unlock-windows" . "Unlock input and eat windows")
-      ("enkan-simple-3pane-send-escape" . "Send ESC to eat buffer (Esc)")
-      ("enkan-simple-3pane-send-1" . "Send 1 to eat buffer (C-M-1)")
-      ("enkan-simple-3pane-send-2" . "Send 2 to eat buffer (C-M-2)")
-      ("enkan-simple-3pane-send-3" . "Send 3 to eat buffer (C-M-3)")))
+      ("enkan-simple-3pane-unlock-windows" . "Unlock input and eat windows")))
   "Additional commands for 3-pane layout to add to cheat sheet.")
 
 ;;; ========================================
@@ -149,10 +145,6 @@ This is set automatically when enkan-simple-3pane-setup is called.")
       ;; These bindings override the base keybindings when 3pane mode is active
       (define-key map (kbd "C-t") 'enkan-simple-3pane-other-window)
       (define-key map (kbd "M-t") 'other-window)
-      (define-key map (kbd "<escape>") 'enkan-simple-3pane-send-escape)
-      (define-key map (kbd "C-M-1") 'enkan-simple-3pane-send-1)
-      (define-key map (kbd "C-M-2") 'enkan-simple-3pane-send-2)
-      (define-key map (kbd "C-M-3") 'enkan-simple-3pane-send-3)
       map)))
 
 ;;; ========================================
@@ -302,11 +294,7 @@ This is set automatically when enkan-simple-3pane-setup is called.")
     (if (boundp 'enkan-simple-3pane-keybinding-overrides)
         (princ (enkan-keybinding-format-description enkan-simple-3pane-keybinding-overrides))
       ;; Fallback if constants not loaded
-      (princ "  C-t         - Switch between input/misc windows\n")
-      (princ "  ESC         - Send ESC to eat buffer\n")
-      (princ "  C-M-1       - Send 1 to eat buffer\n")
-      (princ "  C-M-2       - Send 2 to eat buffer\n")
-      (princ "  C-M-3       - Send 3 to eat buffer\n"))
+      (princ "  C-t         - Switch between input/misc windows\n"))
     
     (princ "\nNote: 3pane mode overrides take precedence over base keybindings.\n")))
 
@@ -376,45 +364,6 @@ Avoids switching to eat window."
       (message "Unlocked windows: %s"
         (string-join (nreverse unlocked-windows) ", "))
       (message "No windows to unlock."))))
-
-;;; ========================================
-;;; Remote eat Control Functions
-;;; ========================================
-
-(defun enkan-simple-3pane-send-escape ()
-  "Send ESC to eat buffer from any window."
-  (interactive)
-  (enkan-simple-3pane--send-to-eat
-    'enkan-repl-send-escape "ESC"))
-
-(defun enkan-simple-3pane-send-1 ()
-  "Send choice 1 to eat buffer from any window."
-  (interactive)
-  (enkan-simple-3pane--send-to-eat
-    'enkan-repl-send-1 "1"))
-
-(defun enkan-simple-3pane-send-2 ()
-  "Send choice 2 to eat buffer from any window."
-  (interactive)
-  (enkan-simple-3pane--send-to-eat
-    'enkan-repl-send-2 "2"))
-
-(defun enkan-simple-3pane-send-3 ()
-  "Send choice 3 to eat buffer from any window."
-  (interactive)
-  (enkan-simple-3pane--send-to-eat
-    'enkan-repl-send-3 "3"))
-
-(defun enkan-simple-3pane--send-to-eat (func msg)
-  "Helper function to send commands to eat buffer.
-FUNC is the function to call, MSG is the message to display."
-  (if (and enkan-simple-3pane-eat-right-full-window
-        (window-live-p enkan-simple-3pane-eat-right-full-window))
-    (save-window-excursion
-      (select-window enkan-simple-3pane-eat-right-full-window)
-      (funcall func)
-      (message "Sent %s to eat buffer" msg))
-    (message "No eat window found. Run M-x enkan-simple-3pane-setup first.")))
 
 ;;; ========================================
 ;;; Display Buffer Management

--- a/examples/test/keybinding-test.el
+++ b/examples/test/keybinding-test.el
@@ -1,0 +1,98 @@
+;;; keybinding-test.el --- Tests for keybinding configuration -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Tests for keybinding definitions and 3pane mode integration
+
+;;; Code:
+
+(require 'ert)
+
+;; Load the files to test
+(let ((dir (file-name-directory (or load-file-name buffer-file-name))))
+  (add-to-list 'load-path (expand-file-name ".." dir))
+  (add-to-list 'load-path (expand-file-name "../.." dir)))
+
+(require 'keybinding-constants)
+(require 'keybinding)
+
+;;;; Tests for base keybinding definitions
+
+(ert-deftest test-base-keybindings-include-send-4-and-5 ()
+  "Test that base keybindings include send-4 and send-5."
+  (let ((keys (mapcar #'car enkan-keybinding-definitions)))
+    (should (member "C-M-4" keys))
+    (should (member "C-M-5" keys))))
+
+(ert-deftest test-send-4-and-5-commands ()
+  "Test that send-4 and send-5 commands are properly defined."
+  (let ((binding-4 (assoc "C-M-4" enkan-keybinding-definitions #'string=))
+        (binding-5 (assoc "C-M-5" enkan-keybinding-definitions #'string=)))
+    (should binding-4)
+    (should binding-5)
+    (should (eq (nth 1 binding-4) 'enkan-repl-send-4))
+    (should (eq (nth 1 binding-5) 'enkan-repl-send-5))
+    (should (string= (nth 2 binding-4) "Send 4 to REPL"))
+    (should (string= (nth 2 binding-5) "Send 5 to REPL"))
+    (should (eq (nth 3 binding-4) 'quick-actions))
+    (should (eq (nth 3 binding-5) 'quick-actions))))
+
+;;;; Tests for 3pane mode overrides
+
+(ert-deftest test-3pane-mode-no-send-overrides ()
+  "Test that 3pane mode does not override send-1 through send-5."
+  (let ((overridden-keys (mapcar #'car enkan-simple-3pane-keybinding-overrides)))
+    ;; These should NOT be in the override list
+    (should-not (member "<escape>" overridden-keys))
+    (should-not (member "C-M-1" overridden-keys))
+    (should-not (member "C-M-2" overridden-keys))
+    (should-not (member "C-M-3" overridden-keys))
+    (should-not (member "C-M-4" overridden-keys))
+    (should-not (member "C-M-5" overridden-keys))
+    ;; Only C-M-t should be overridden
+    (should (member "C-M-t" overridden-keys))))
+
+(ert-deftest test-3pane-command-definitions-no-send-functions ()
+  "Test that 3pane command definitions don't include send functions."
+  (let ((commands (mapcar #'car enkan-simple-3pane-command-definitions)))
+    (should-not (memq 'enkan-simple-3pane-send-escape commands))
+    (should-not (memq 'enkan-simple-3pane-send-1 commands))
+    (should-not (memq 'enkan-simple-3pane-send-2 commands))
+    (should-not (memq 'enkan-simple-3pane-send-3 commands))
+    (should-not (memq 'enkan-simple-3pane-send-4 commands))
+    (should-not (memq 'enkan-simple-3pane-send-5 commands))))
+
+;;;; Tests for dual-task mode
+
+(ert-deftest test-dual-task-mode-minimal-overrides ()
+  "Test that dual-task mode has minimal overrides."
+  (let ((overridden-keys (mapcar #'car enkan-dual-task-keybinding-overrides)))
+    ;; Only C-M-t should be overridden
+    (should (= 1 (length overridden-keys)))
+    (should (member "C-M-t" overridden-keys))))
+
+;;;; Tests for keymap creation
+
+(ert-deftest test-keymap-creation ()
+  "Test that keymaps can be created from definitions."
+  (let ((keymap (enkan-keybinding-make-keymap enkan-keybinding-definitions)))
+    (should (keymapp keymap))
+    ;; Check that send-4 and send-5 are in the keymap
+    (should (lookup-key keymap (kbd "C-M-4")))
+    (should (lookup-key keymap (kbd "C-M-5")))))
+
+(ert-deftest test-3pane-keymap-no-send-overrides ()
+  "Test that 3pane keymap doesn't override send keys."
+  (let ((keymap (enkan-keybinding-make-keymap enkan-simple-3pane-keybinding-overrides)))
+    (should (keymapp keymap))
+    ;; These should NOT be in the 3pane override keymap
+    (should-not (lookup-key keymap (kbd "<escape>")))
+    (should-not (lookup-key keymap (kbd "C-M-1")))
+    (should-not (lookup-key keymap (kbd "C-M-2")))
+    (should-not (lookup-key keymap (kbd "C-M-3")))
+    (should-not (lookup-key keymap (kbd "C-M-4")))
+    (should-not (lookup-key keymap (kbd "C-M-5")))
+    ;; Only C-M-t should be in the override keymap
+    (should (lookup-key keymap (kbd "C-M-t")))))
+
+(provide 'keybinding-test)
+;;; keybinding-test.el ends here


### PR DESCRIPTION
## Summary
- Add support for keybindings 4 and 5 (C-M-4, C-M-5) to match Claude Code's new 4-option feature
- Remove 3pane-specific send functions to unify with dual-task approach

## Changes
- Added C-M-4 and C-M-5 to standard keybindings in `keybinding-constants.el`
- Removed 3pane-mode specific send-1~5 function overrides
- Removed redundant send function implementations from `simple-3pane-window-layout.el`
- Added comprehensive tests to verify the changes

## Test plan
- [x] All existing tests pass
- [x] New tests added for keybinding configuration
- [x] Verified that 3pane mode uses standard keybindings
- [x] Confirmed dual-task mode remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)