### PR TITLE
fix: add keymap refresh call in keybinding example

### DIFF
--- a/examples/keybinding.el
+++ b/examples/keybinding.el
@@ -36,6 +36,9 @@
        ("C-M-t"   . enkan-repl-teardown)
        ("C-M-l"   . enkan-repl-setup-current-project-layout))))
 
+;; Refresh keymap after setting bindings
+(enkan-repl--refresh-global-minor-map)
+
 (provide 'keybinding)
 
 ;;; keybinding.el ends here


### PR DESCRIPTION
## Summary
- Add `enkan-repl--refresh-global-minor-map` call after setting key bindings in the example configuration
- Ensures keymap is properly refreshed when the example configuration is loaded

## Test plan
- [ ] Load the example keybinding configuration
- [ ] Verify that key bindings are properly applied
- [ ] Confirm that the keymap refresh function is called

🤖 Generated with [Claude Code](https://claude.ai/code)