### PR TITLE
PR-5: Session scope filtering for workspaces

### DIFF
--- a/enkan-repl-mac-notify.el
+++ b/enkan-repl-mac-notify.el
@@ -39,6 +39,9 @@
 
 (require 'enkan-repl-utils)
 
+;; Declare functions from enkan-repl-utils
+(declare-function enkan-repl--is-enkan-buffer-name "enkan-repl-utils" (name))
+
 (defgroup enkan-repl-notifications nil
   "Customization options for enkan-repl notifications."
   :group 'enkan-repl)
@@ -113,7 +116,7 @@ Use this if system notifications aren't working after starting a session."
   (interactive)
   ;; Find eat buffer matching pattern *ws:XX enkan:*
   (let ((eat-buffer (seq-find (lambda (buf)
-                                (string-match-p "^\\*ws:[0-9]\\{2\\} enkan:.*\\*$" (buffer-name buf)))
+                                (enkan-repl--is-enkan-buffer-name (buffer-name buf)))
                               (buffer-list))))
     (when eat-buffer
       (with-current-buffer eat-buffer

--- a/enkan-repl-utils.el
+++ b/enkan-repl-utils.el
@@ -43,6 +43,20 @@ Returns buffer name in format *ws:01 enkan:<expanded-path>*.
 Always uses workspace ID 01 for now (single workspace mode)."
   (format "*ws:01 enkan:%s*" (expand-file-name path)))
 
+(defun enkan-repl--buffer-name-matches-workspace (name workspace-id)
+  "Check if buffer NAME belongs to WORKSPACE-ID.
+Returns t if the buffer name has the correct workspace prefix."
+  (and (stringp name)
+       (stringp workspace-id)
+       (string-match-p (format "^\\*ws:%s enkan:" workspace-id) name)))
+
+(defun enkan-repl--extract-workspace-id (name)
+  "Extract workspace ID from buffer NAME.
+Returns workspace ID string (e.g., \"01\") or nil if not an enkan buffer."
+  (when (and (stringp name)
+             (string-match "^\\*ws:\\([0-9]\\{2\\}\\) enkan:" name))
+    (match-string 1 name)))
+
 ;;;; Session List Pure Functions
 
 (defun enkan-repl--extract-project-name (buffer-name-or-path)

--- a/enkan-repl-utils.el
+++ b/enkan-repl-utils.el
@@ -62,9 +62,8 @@ Returns workspace ID string (e.g., \"01\") or nil if not an enkan buffer."
 (defun enkan-repl--extract-project-name (buffer-name-or-path)
   "Extract final directory name from buffer name or path for use as project name.
 Example: \\='*ws:01 enkan:/path/to/pt-tools/*\\=' -> \\='pt-tools\\='"
-  (let ((path (if (string-match "\\*ws:[0-9]\\{2\\} enkan:\\(.+\\)\\*" buffer-name-or-path)
-                  (match-string 1 buffer-name-or-path)
-                buffer-name-or-path)))
+  (let ((path (or (enkan-repl--buffer-name->path buffer-name-or-path)
+                   buffer-name-or-path)))
     (file-name-nondirectory (directory-file-name path))))
 
 (defun enkan-repl--encode-full-path (path prefix separator)
@@ -122,8 +121,8 @@ PROCESS-LIVE-P indicates if the process is alive.
 Returns a plist with :name, :directory, and :status, or nil if not a session."
   (when (and buffer-name
              buffer-live-p
-             (string-match "^\\*ws:[0-9]\\{2\\} enkan:\\(.*?\\)\\*$" buffer-name))
-    (let ((dir (match-string 1 buffer-name))
+             (enkan-repl--is-enkan-buffer-name buffer-name))
+    (let ((dir (enkan-repl--buffer-name->path buffer-name))
           (status (if (and has-eat-process process-live-p)
                       'alive
                     'dead)))
@@ -178,19 +177,24 @@ or nil if not on a session entry."
       ;; Check if we're on or near a session entry
       (cond
        ;; On session name line
-       ((string-match "^  \\*ws:[0-9]\\{2\\} enkan:" line)
+       ((and (>= (length line) 2)
+             (enkan-repl--is-enkan-buffer-name (substring line 2)))
         (list :start-line current-line
               :end-line (min (+ current-line 4) (length lines))))
        ;; On directory line
        ((and (> current-line 0)
              (string-match "^    Directory:" line)
-             (string-match "^  \\*ws:[0-9]\\{2\\} enkan:" (nth (1- current-line) lines)))
+             (let ((prev-line (nth (1- current-line) lines)))
+               (and (>= (length prev-line) 2)
+                    (enkan-repl--is-enkan-buffer-name (substring prev-line 2)))))
         (list :start-line (1- current-line)
               :end-line (min (+ current-line 3) (length lines))))
        ;; On status line
        ((and (> current-line 1)
              (string-match "^    Status:" line)
-             (string-match "^  \\*ws:[0-9]\\{2\\} enkan:" (nth (- current-line 2) lines)))
+             (let ((prev-prev-line (nth (- current-line 2) lines)))
+               (and (>= (length prev-prev-line) 2)
+                    (enkan-repl--is-enkan-buffer-name (substring prev-prev-line 2)))))
         (list :start-line (- current-line 2)
               :end-line (min (+ current-line 2) (length lines))))
        (t nil)))))
@@ -464,9 +468,8 @@ Returns formatted string."
      (let ((name (plist-get session :name))
            (status (plist-get session :status)))
        (format "%s [%s]"
-               (if (string-match "\\*ws:[0-9]\\{2\\} enkan:\\(.*?\\)\\*" name)
-                   (match-string 1 name)
-                 name)
+               (or (enkan-repl--buffer-name->path name)
+                   name)
                (upcase (symbol-name status)))))
    sessions
    "\n"))

--- a/test/enkan-repl-workspace-scope-test.el
+++ b/test/enkan-repl-workspace-scope-test.el
@@ -1,0 +1,115 @@
+;;; enkan-repl-workspace-scope-test.el --- Tests for workspace scope filtering -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Test cases for workspace-scoped buffer filtering
+
+;;; Code:
+
+(require 'ert)
+(require 'enkan-repl)
+(require 'enkan-repl-utils)
+
+(ert-deftest test-enkan-repl--buffer-name-matches-workspace ()
+  "Test workspace matching in buffer names."
+  ;; Test matching workspace
+  (should (enkan-repl--buffer-name-matches-workspace
+           "*ws:01 enkan:/home/user/project*" "01"))
+  
+  ;; Test non-matching workspace
+  (should-not (enkan-repl--buffer-name-matches-workspace
+               "*ws:02 enkan:/home/user/project*" "01"))
+  
+  ;; Test invalid buffer name
+  (should-not (enkan-repl--buffer-name-matches-workspace
+               "*enkan:/home/user/project*" "01"))
+  
+  ;; Test nil inputs
+  (should-not (enkan-repl--buffer-name-matches-workspace nil "01"))
+  (should-not (enkan-repl--buffer-name-matches-workspace "*ws:01 enkan:/path*" nil)))
+
+(ert-deftest test-enkan-repl--extract-workspace-id ()
+  "Test extraction of workspace ID from buffer names."
+  ;; Test valid workspace buffer
+  (should (equal (enkan-repl--extract-workspace-id
+                  "*ws:01 enkan:/home/user/project*") "01"))
+  
+  ;; Test different workspace ID
+  (should (equal (enkan-repl--extract-workspace-id
+                  "*ws:99 enkan:/home/user/project*") "99"))
+  
+  ;; Test invalid format
+  (should-not (enkan-repl--extract-workspace-id
+               "*enkan:/home/user/project*"))
+  
+  ;; Test nil input
+  (should-not (enkan-repl--extract-workspace-id nil)))
+
+(ert-deftest test-enkan-repl--get-available-buffers-with-workspace ()
+  "Test that get-available-buffers filters by workspace."
+  ;; Save current workspace
+  (let ((original-ws enkan-repl--current-workspace))
+    (unwind-protect
+        (progn
+          ;; Set current workspace to 01
+          (setq enkan-repl--current-workspace "01")
+          
+          ;; Create mock buffers with different workspace IDs
+          (let* ((buffer-ws01-1 (get-buffer-create "*ws:01 enkan:/project1*"))
+                 (buffer-ws01-2 (get-buffer-create "*ws:01 enkan:/project2*"))
+                 (buffer-ws02 (get-buffer-create "*ws:02 enkan:/project3*"))
+                 (buffer-list (list buffer-ws01-1 buffer-ws01-2 buffer-ws02)))
+            
+            ;; Mock eat--process for testing
+            (dolist (buf (list buffer-ws01-1 buffer-ws01-2 buffer-ws02))
+              (with-current-buffer buf
+                (setq-local eat--process 'mock-process)))
+            
+            ;; Mock process-live-p
+            (cl-letf (((symbol-function 'process-live-p) (lambda (_) t)))
+              ;; Test filtering - should only return ws:01 buffers
+              (let ((result (enkan-repl--get-available-buffers buffer-list)))
+                (should (= (length result) 2))
+                (should (member buffer-ws01-1 result))
+                (should (member buffer-ws01-2 result))
+                (should-not (member buffer-ws02 result))))
+            
+            ;; Clean up buffers
+            (dolist (buf buffer-list)
+              (kill-buffer buf))))
+      ;; Restore original workspace
+      (setq enkan-repl--current-workspace original-ws))))
+
+(ert-deftest test-enkan-repl--get-buffer-for-directory-with-workspace ()
+  "Test that get-buffer-for-directory filters by workspace."
+  ;; Save current workspace
+  (let ((original-ws enkan-repl--current-workspace))
+    (unwind-protect
+        (progn
+          ;; Set current workspace to 01
+          (setq enkan-repl--current-workspace "01")
+          
+          ;; Create mock buffers
+          (let* ((buffer-ws01 (get-buffer-create "*ws:01 enkan:/home/test*"))
+                 (buffer-ws02 (get-buffer-create "*ws:02 enkan:/home/test*")))
+            
+            ;; Mock eat-mode for both buffers
+            (dolist (buf (list buffer-ws01 buffer-ws02))
+              (with-current-buffer buf
+                (setq-local eat-mode t)))
+            
+            ;; Mock enkan-repl--buffer-matches-directory to return true
+            (cl-letf (((symbol-function 'enkan-repl--buffer-matches-directory)
+                       (lambda (name dir) t)))
+              ;; Should return ws:01 buffer, not ws:02
+              (let ((result (enkan-repl--get-buffer-for-directory "/home/test")))
+                (should (eq result buffer-ws01))))
+            
+            ;; Clean up buffers
+            (kill-buffer buffer-ws01)
+            (kill-buffer buffer-ws02)))
+      ;; Restore original workspace
+      (setq enkan-repl--current-workspace original-ws))))
+
+(provide 'enkan-repl-workspace-scope-test)
+
+;;; enkan-repl-workspace-scope-test.el ends here


### PR DESCRIPTION
## Summary
セッション探索を現在のワークスペース（ws:01）のみを対象にする機能を実装

## Changes
- [ ] `enkan-repl--get-buffer-for-directory`: 現在のWSのバッファのみを返すよう変更
- [ ] `enkan-repl--get-available-buffers`: WSトークンでフィルタリング
- [ ] テスト追加: 異なるWSトークンのバッファが混在してもフィルタリングされることを確認

## Test plan
- [ ] `make check` が緑であることを確認
- [ ] 異なるWSトークンのバッファが混在してもフィルタリングされることを確認
- [ ] 現在のWSのセッションのみがヒットすることを確認

## Related
- Part of workspaces feature implementation
- Follows PR-4 (workspace-prefixed buffer naming)