### PR TITLE
PR-10: Remove legacy wrapper functions

### DIFF
--- a/enkan-repl-utils.el
+++ b/enkan-repl-utils.el
@@ -92,17 +92,6 @@ Example: \='enkan--Users--project\=' + \='enkan\=' + \='--\=' -> \='/Users/proje
         ((path-part (substring encoded-name (length prefix))))  ; Remove prefix
       (concat (replace-regexp-in-string (regexp-quote separator) "/" path-part) "/"))))
 
-(defun enkan-repl--extract-directory-from-buffer-name (buffer-name)
-  "Pure function to extract expanded directory path from enkan buffer name.
-Returns expanded directory path or nil if buffer name is not valid enkan format."
-  ;; Thin wrapper around new API for compatibility
-  (enkan-repl--buffer-name->path buffer-name))
-
-(defun enkan-repl--make-buffer-name (path)
-  "Create buffer name for given PATH.
-Returns buffer name in format *enkan:<expanded-path>*"
-  ;; Thin wrapper around new API for compatibility
-  (enkan-repl--path->buffer-name path))
 
 (defun enkan-repl--buffer-matches-directory (buffer-name target-directory)
   "Pure function to check if buffer name matches target directory.

--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -74,9 +74,7 @@
 (declare-function enkan-repl--get-current-session-state-info "enkan-repl-utils" (current-project session-list session-counter project-aliases))
 (declare-function enkan-repl-utils--encode-full-path "enkan-repl-utils" (path prefix separator))
 (declare-function enkan-repl-utils--decode-full-path "enkan-repl-utils" (encoded-name prefix separator))
-(declare-function enkan-repl--make-buffer-name "enkan-repl-utils" (path))
 (declare-function enkan-repl--buffer-matches-directory "enkan-repl-utils" (buffer-name target-directory))
-(declare-function enkan-repl--extract-directory-from-buffer-name "enkan-repl-utils" (buffer-name))
 (declare-function enkan-repl--extract-project-name "enkan-repl-utils" (buffer-name-or-path))
 (declare-function enkan-repl--is-enkan-buffer-name "enkan-repl-utils" (name))
 (declare-function enkan-repl--buffer-name->path "enkan-repl-utils" (name))
@@ -610,7 +608,7 @@ Returns: Directory path or nil"
                    (string-equal project-name
                                  (enkan-repl--extract-project-name (buffer-name))))
           (cl-return-from search-buffers
-            (enkan-repl--extract-directory-from-buffer-name (buffer-name))))))))
+            (enkan-repl--buffer-name->path (buffer-name))))))))
 
 (defun enkan-repl--get-buffer-for-directory (&optional directory)
   "Get the eat buffer for DIRECTORY if it exists and is live.
@@ -874,7 +872,7 @@ Category: Session Controller"
   (require 'eat)
   ;; Always start new eat session in current directory
   (let* ((target-dir default-directory)
-         (buffer-name (enkan-repl--make-buffer-name target-dir))
+         (buffer-name (enkan-repl--path->buffer-name target-dir))
          (eat-buffer (eat)))
     ;; Simple buffer renaming - no error handling
     (when eat-buffer
@@ -1246,7 +1244,7 @@ Returns a plist with :status and other keys."
                            current-project projects target-directories)))
          ;; Helper function to convert path to buffer
          (path-to-buffer (lambda (path)
-                           (get-buffer (enkan-repl--make-buffer-name path))))
+                           (get-buffer (enkan-repl--path->buffer-name path))))
          ;; Helper function to check if buffer exists
          (get-active-buffers (lambda (paths)
                                (cl-loop for (alias . path) in paths

--- a/test/enkan-repl-name-api-test.el
+++ b/test/enkan-repl-name-api-test.el
@@ -77,16 +77,16 @@
 ;;;; Compatibility tests - verify old and new APIs return same results
 
 (ert-deftest test-enkan-repl-name-api-compatibility ()
-  "Test that old wrapper functions still work with new format."
-  ;; Test enkan-repl--extract-directory-from-buffer-name with new format
+  "Test that new API functions work correctly with new format."
+  ;; Test enkan-repl--buffer-name->path with new format
   (let* ((buffer-name "*ws:01 enkan:/home/user/project*")
-         (result (enkan-repl--extract-directory-from-buffer-name buffer-name)))
+         (result (enkan-repl--buffer-name->path buffer-name)))
     (should (stringp result))
     (should (string-match "/home/user/project/$" result)))
   
-  ;; Test enkan-repl--make-buffer-name generates new format
+  ;; Test enkan-repl--path->buffer-name generates new format
   (let* ((path "/home/user/project")
-         (result (enkan-repl--make-buffer-name path)))
+         (result (enkan-repl--path->buffer-name path)))
     (should (string-prefix-p "*ws:01 enkan:" result))
     (should (string-match "\\*ws:01 enkan:/home/user/project\\*" result)))
   


### PR DESCRIPTION
## Summary

Remove legacy wrapper functions that were replaced with new API in PR-3.

## Changes

- Remove `enkan-repl--extract-directory-from-buffer-name` (replaced by `enkan-repl--buffer-name->path`)
- Remove `enkan-repl--make-buffer-name` (replaced by `enkan-repl--path->buffer-name`)
- Update all call sites to use new API functions

## Completion Criteria

- [ ] All references to legacy functions removed
- [ ] All tests pass
- [ ] `make check` passes

## Related

- See PR-10 section in docs/workspaces.md
- Follows PR-3 where these were marked as wrappers