### PR TITLE
feat: workspace teardown standardization

### DIFF
--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -1064,7 +1064,10 @@ Category: Session Controller"
               (kill-buffer existing-buffer)
               (message "Terminated eat session in: %s" target-dir)
               ;; Delete current workspace after session termination
-              (enkan-repl--teardown-delete-current-workspace-pure)))))
+              (enkan-repl--teardown-delete-current-workspace-pure)
+              ;; Switch to another workspace if available
+              (when (enkan-repl--list-workspace-ids enkan-repl--workspaces)
+                (enkan-repl-workspace-switch))))))
       ;; Center file mode: terminate all sessions in current workspace
       (if (enkan-repl--is-center-file-path enkan-repl-center-file enkan-repl-projects)
           ;; Center file mode implementation
@@ -1108,6 +1111,9 @@ Category: Session Controller"
                             (princ (format "  ❌ Session %d: %s (project path not found)\n" session-number project-name)))))))
                     ;; Reset global configuration and delete current workspace
                     (enkan-repl--teardown-delete-current-workspace-pure)
+                    ;; Switch to another workspace if available
+                    (when (enkan-repl--list-workspace-ids enkan-repl--workspaces)
+                      (enkan-repl-workspace-switch))
                     ;; Auto-disable global center file mode
                     ;; (when (enkan-repl--disable-global-minor-mode-if-active)
                     ;;   (princ "\n🔄 Auto-disabled center file global mode\n"))

--- a/test/enkan-repl-teardown-workspace-deletion-test.el
+++ b/test/enkan-repl-teardown-workspace-deletion-test.el
@@ -1,0 +1,46 @@
+;;; enkan-repl-teardown-workspace-deletion-test.el --- Test workspace deletion in teardown -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Test that teardown actually deletes workspaces
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+
+;; Load required files
+(load (expand-file-name "enkan-repl.el" default-directory) nil t)
+(load (expand-file-name "enkan-repl-utils.el" default-directory) nil t)
+
+(ert-deftest test-teardown-deletes-workspace-pure-function ()
+  "Test that enkan-repl--teardown-delete-current-workspace-pure deletes workspace."
+  (let ((enkan-repl--workspaces '(("01" . (:current-project "test" :session-list ((1 . "test")) :session-counter 1 :project-aliases nil))
+                                   ("02" . (:current-project "other" :session-list ((1 . "other")) :session-counter 1 :project-aliases nil))))
+        (enkan-repl--current-workspace "01")
+        (enkan-repl-session-list '((1 . "test")))
+        (enkan-repl--session-counter 1)
+        (enkan-repl--current-project "test")
+        (enkan-repl-project-aliases nil))
+    
+    ;; Verify initial state
+    (should (equal "01" enkan-repl--current-workspace))
+    (should (equal 2 (length enkan-repl--workspaces)))
+    (should (assoc "01" enkan-repl--workspaces))
+    
+    ;; Execute deletion
+    (enkan-repl--teardown-delete-current-workspace-pure)
+    
+    ;; Verify workspace was deleted
+    (should (equal nil enkan-repl--current-workspace))
+    (should (equal 1 (length enkan-repl--workspaces)))
+    (should (not (assoc "01" enkan-repl--workspaces)))
+    (should (assoc "02" enkan-repl--workspaces))
+    
+    ;; Verify session variables were reset
+    (should (equal nil enkan-repl-session-list))
+    (should (equal 0 enkan-repl--session-counter))
+    (should (equal nil enkan-repl--current-project))
+    (should (equal nil enkan-repl-project-aliases))))
+
+(provide 'enkan-repl-teardown-workspace-deletion-test)
+;;; enkan-repl-teardown-workspace-deletion-test.el ends here

--- a/test/enkan-repl-teardown-workspace-switch-test.el
+++ b/test/enkan-repl-teardown-workspace-switch-test.el
@@ -1,0 +1,81 @@
+;;; enkan-repl-teardown-workspace-switch-test.el --- Test workspace switching after teardown -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Test that teardown switches to another workspace when available
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+
+;; Load required files
+(load (expand-file-name "enkan-repl.el" default-directory) nil t)
+(load (expand-file-name "enkan-repl-utils.el" default-directory) nil t)
+
+(ert-deftest test-teardown-switches-to-remaining-workspace ()
+  "Test that teardown switches to remaining workspace when available."
+  (let ((enkan-repl--workspaces '(("01" . (:current-project "test" :session-list ((1 . "test")) :session-counter 1 :project-aliases nil))
+                                   ("02" . (:current-project "other" :session-list ((1 . "other")) :session-counter 1 :project-aliases nil))))
+        (enkan-repl--current-workspace "01")
+        (enkan-repl-session-list '((1 . "test")))
+        (enkan-repl--session-counter 1)
+        (enkan-repl--current-project "test")
+        (enkan-repl-project-aliases nil)
+        (workspace-switch-called nil))
+    
+    ;; Mock enkan-repl-workspace-switch to verify it's called
+    (cl-letf (((symbol-function 'enkan-repl-workspace-switch)
+               (lambda ()
+                 (setq workspace-switch-called t)
+                 ;; Simulate switching to workspace 02
+                 (setq enkan-repl--current-workspace "02")
+                 (enkan-repl--load-workspace-state "02"))))
+      
+      ;; Execute deletion
+      (enkan-repl--teardown-delete-current-workspace-pure)
+      
+      ;; Verify workspace was deleted
+      (should (equal 1 (length enkan-repl--workspaces)))
+      (should (not (assoc "01" enkan-repl--workspaces)))
+      (should (assoc "02" enkan-repl--workspaces))
+      
+      ;; Now test the teardown flow with workspace switching
+      ;; Since we have remaining workspace, switch should be triggered
+      (when (enkan-repl--list-workspace-ids enkan-repl--workspaces)
+        (enkan-repl-workspace-switch))
+      
+      ;; Verify workspace switch was called
+      (should workspace-switch-called)
+      (should (equal "02" enkan-repl--current-workspace)))))
+
+(ert-deftest test-teardown-no-switch-when-no-workspaces ()
+  "Test that teardown doesn't switch when no workspaces remain."
+  (let ((enkan-repl--workspaces '(("01" . (:current-project "test" :session-list ((1 . "test")) :session-counter 1 :project-aliases nil))))
+        (enkan-repl--current-workspace "01")
+        (enkan-repl-session-list '((1 . "test")))
+        (enkan-repl--session-counter 1)
+        (enkan-repl--current-project "test")
+        (enkan-repl-project-aliases nil)
+        (workspace-switch-called nil))
+    
+    ;; Mock enkan-repl-workspace-switch
+    (cl-letf (((symbol-function 'enkan-repl-workspace-switch)
+               (lambda ()
+                 (setq workspace-switch-called t))))
+      
+      ;; Execute deletion
+      (enkan-repl--teardown-delete-current-workspace-pure)
+      
+      ;; Verify workspace was deleted
+      (should (equal 0 (length enkan-repl--workspaces)))
+      (should (equal nil enkan-repl--current-workspace))
+      
+      ;; Test the teardown flow - should not call switch when no workspaces
+      (when (enkan-repl--list-workspace-ids enkan-repl--workspaces)
+        (enkan-repl-workspace-switch))
+      
+      ;; Verify workspace switch was NOT called
+      (should-not workspace-switch-called))))
+
+(provide 'enkan-repl-teardown-workspace-switch-test)
+;;; enkan-repl-teardown-workspace-switch-test.el ends here


### PR DESCRIPTION
## Summary
Implement Step B of workspace standardization as documented in `docs/brushup-workspace.md`.

## Implementation Plan
- **Step B**: Teardown standardization
  - Session termination: End all sessions registered to current workspace
  - WS deletion: Remove current workspace and reset its configuration
  - Next active WS selection rules:
    - 0 remaining WSs → `enkan-repl--current-workspace` = nil
    - 1 remaining WS → Auto-switch to the only workspace
    - 2+ remaining WSs → Use `hmenu` for user selection

## Acceptance Criteria
- [ ] Teardown execution deletes current WS and follows 0/1/2+ rules for next active WS
- [ ] Session termination works correctly for all registered sessions
- [ ] Integration with existing teardown process (standard/center file paths unified)
- [ ] All tests pass (`make test` and `make check` are green)

## Related Files
- Implementation: `enkan-repl.el` (`enkan-repl-teardown`, new helpers)
- Tests: `test/enkan-repl-workspace-setup-teardown-test.el` and others

## Dependencies  
- Builds on Step A implementation (workspace creation with project linking)

🤖 Generated with [Claude Code](https://claude.ai/code)