### PR TITLE
chore(refactor): Phase 0 - normalize autoload cookies (public-only)

### DIFF
--- a/enkan-repl.el
+++ b/enkan-repl.el
@@ -1615,7 +1615,7 @@ Returns t if mode was disabled, nil otherwise."
     (enkan-repl-global-minor-mode -1)
     t))
 
-;;;###autoload
+;; Private; do not autoload
 (defun enkan-repl--get-buffer-process-info (buffer)
   "Pure function to get process info for BUFFER.
 Returns plist with :buffer, :name, :live-p, :has-process, :process."
@@ -1873,7 +1873,7 @@ Category: Center File Multi-buffer Access"
       ('cancelled
        (message "Selection cancelled")))))
 
-;;;###autoload
+;; Private; do not autoload
 (defun enkan-repl--analyze-send-content (content pfx)
   "Pure function to analyze CONTENT with PFX and determine action.
 CONTENT is the text content to analyze.
@@ -1965,6 +1965,7 @@ Returns plist with :valid, :action, :message."
                            "Creating new center file")))
       validation)))
 
+;;;###autoload
 (defun enkan-repl-open-center-file ()
   "Open or create the center file based on enkan-repl-center-file configuration.
 


### PR DESCRIPTION
Purpose\n- Normalize autoload cookies: keep them only on public, interactive commands.\n- Remove autoload cookies from private helpers (double-dash names).\n- Add missing autoload on `enkan-repl-open-center-file`.\n\nScope\n- Mechanical change only; no behavior changes.\n- Touched: enkan-repl.el (comments/metadata lines only).\n\nAcceptance Criteria\n- CI green (`make check`) on Emacs 30.1.\n- Byte-compile/package-lint warnings do not increase.\n- Diff small (<= 10 LOC).\n\nRisk / Rollback\n- Very low; revert is trivial.\n\nNext\n- Phase 0 continues with docstring/header normalization where needed.\n\nNotes\n- Refactoring roadmap tracked locally at docs/refactoring-plan-2025-09.md (currently gitignored).