### PR TITLE
fix: Phase 0 - utils header metadata only (no formatting changes)

### DIFF
--- a/enkan-repl-utils.el
+++ b/enkan-repl-utils.el
@@ -2,7 +2,8 @@
 
 ;; Copyright (C) 2025 [phasetr]
 
-;; Author: [phasetr] <phasetr@gmail.com>
+;; Author: phasetr <phasetr@gmail.com>
+;; URL: https://github.com/phasetr/enkan-repl
 ;; Keywords: tools
 ;; Package-Requires: ((emacs "28.2") (cl-lib "0.5"))
 


### PR DESCRIPTION
Summary

- Phase 0 (safety net): header/docstring metadata only.
- Adjust enkan-repl-utils.el header: Author/URL fields.
- No functional changes; keep all existing strings and glyphs intact.

Why

- Keep PRs tiny, behavior-neutral, and easy to review.
- Align metadata across files without touching runtime paths or tests.

Verification

- make check: green (tests, compile, checkdoc, package-lint, format).
- Diff is minimal (comments only).

Next

- Continue Phase 0 in small batches (autoload cleanup already merged, doc/header alignments next where safe).
